### PR TITLE
Add .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _site
 node_modules
 venv
 __pycache__
+.DS_Store


### PR DESCRIPTION
To prevent committing `.DS_Store` files created by MacOS.