### PR TITLE
Fix cross browser UI inconsistencies

### DIFF
--- a/lib/css/shell-general-layout.css
+++ b/lib/css/shell-general-layout.css
@@ -132,6 +132,29 @@ select, input, textarea {
     font-size: inherit;
 }
 
+select,
+select::picker(select) {
+    appearance: base-select;
+}
+
+select {
+    height: 1.5rem;
+}
+
+optgroup {
+    margin: 0.5rem 0;
+}
+
+optgroup > legend,
+option {
+    height: 1.25rem;
+    padding: 0 0.75rem;
+}
+
+optgroup > legend {
+    font-weight: bold;
+}
+
 dialog {
   background-color: var(--background-color-no-alpha, var(--background-color));
   color: var(--text-color);

--- a/lib/css/shell-general-layout.css
+++ b/lib/css/shell-general-layout.css
@@ -155,6 +155,10 @@ optgroup > legend {
     font-weight: bold;
 }
 
+input[type=checkbox] {
+    vertical-align: middle;
+}
+
 dialog {
   background-color: var(--background-color-no-alpha, var(--background-color));
   color: var(--text-color);

--- a/lib/css/shell-general-layout.css
+++ b/lib/css/shell-general-layout.css
@@ -127,6 +127,9 @@ body, select, input, textarea {
 
 select, input, textarea {
     background-color: var(--background-color-no-alpha, var(--background-color));
+    border: 1px solid var(--text-color);
+    font-family: RobotoFlex, sans-serif;
+    font-size: inherit;
 }
 
 dialog {

--- a/lib/js/components/font-loading.mjs
+++ b/lib/js/components/font-loading.mjs
@@ -131,16 +131,18 @@ export class FontSelect extends _BaseComponent {
           , optGroups = {}
           , createOptGroup = name=>{
                 const optgroup = this._domTool.createElement('optgroup');
+                const legend = this._domTool.createElement('legend');
                 switch(name) {
                     case 'from-url':
-                        optgroup.label ='Included fonts';
+                        legend.innerHTML ='Included fonts';
                         break;
                     case 'from-file':
-                        optgroup.label = 'Your local fonts';
+                        legend.innerHTML = 'Your local fonts';
                         break;
                     default:
-                        optgroup.label = `Origin: ${name}`;
+                        legend.innerHTML = `Origin: ${name}`;
                 }
+                optgroup.append(legend);
                 return optgroup;
             }
           , getOptGroup = name=>{

--- a/lib/js/components/generic.mjs
+++ b/lib/js/components/generic.mjs
@@ -145,8 +145,12 @@ export class GenericSelect extends _BaseComponent {
                 .filter(group=>group.createsOptGroup)
                 .sort((a, b)=>a.index-b.index)
                 .map(group=>{
-                    const optGroup = this._domTool.createElement('optgroup')
-                    optGroup.label = group.label;
+                    const optGroup = this._domTool.createElement('optgroup');
+                    // use <legend> to style the <optgroup> label, as recommended by MDN
+                    // https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select#customizing_other_classic_select_features
+                    const legend = this._domTool.createElement('legend');
+                    legend.innerHTML = group.label;
+                    optGroup.append(legend);
                     optGroup.append(...group.items);
                     return optGroup;
                 })

--- a/lib/js/components/ui-char-groups.mjs
+++ b/lib/js/components/ui-char-groups.mjs
@@ -408,17 +408,19 @@ export class PlainSelectCharGroupInput {
           ;
         for(const [groupKey, label, key] of _getCharGroupsStructure(charGroups)) {
             if(!groups.has(groupKey)) {
-                const container = domTool.createElement('optgroup');
-                container.label = groupKey;
-                root.append(container);
-                groups.set(groupKey, container);
+                const optgroup = domTool.createElement('optgroup');
+                const legend = domTool.createElement('legend');
+                legend.innerHTML = groupKey;
+                optgroup.append(legend);
+                root.append(optgroup);
+                groups.set(groupKey, optgroup);
             }
-            const container = groups.get(groupKey)
+            const optgroup = groups.get(groupKey)
               ,  option = domTool.createElement('option')
               ;
             option.textContent = label;
             option.value = key;
-            container.append(option);
+            optgroup.append(option);
         }
         return root;
     }


### PR DESCRIPTION
This PR adds a few adjustments to address cross-browser inconsistencies and customizes the `<select>` styling using the new [appearance: base-select](https://developer.chrome.com/blog/a-customizable-select) CSS property. Currently, this custom styling is only supported on Chrome, but it should be supported on other browsers in the future.