### PR TITLE
[ui] Fix fieldset's top border in forms

### DIFF
--- a/lib/css/shell/elements.css
+++ b/lib/css/shell/elements.css
@@ -111,16 +111,6 @@ dialog label {
 fieldset
 *******************************************************************************/
 
-form fieldset {
-  background-color: var(--background-color);
-  border: var(--gap-size) solid var(--fieldset-border-color);
-  padding: 0.75em;
-}
-
-form fieldset + fieldset {
-  margin-top: 1em;
-}
-
 fieldset {
   border: none;
   border-bottom: 1px solid var(--fieldset-border-color);
@@ -134,6 +124,21 @@ fieldset > legend {
   font-weight: 600;
   padding: 0.5em 0;
   width: 100%;
+}
+
+form fieldset {
+  background-color: var(--background-color);
+  border: var(--gap-size) solid var(--fieldset-border-color);
+  padding: 0.75em;
+}
+
+form fieldset + fieldset {
+  margin-top: 1em;
+}
+
+form fieldset > legend {
+  padding: 0 0.5em;
+  width: auto;
 }
 
 /******************************************************************************


### PR DESCRIPTION
Fix issue with the `fieldset`'s top border not taking the full width of the element.