### PR TITLE
Components/collapsible conainer

### DIFF
--- a/lib/js/components/basics.mjs
+++ b/lib/js/components/basics.mjs
@@ -802,7 +802,7 @@ export class _CommonContainerComponent extends _BaseComponent {
             return parameter;
 
         switch(parameter.name) {
-            case "zones":
+            case "raw:zones":
                 return this._zones;
         }
         throw new Error(`KEY ERROR dependency injection parameter "${parameter.name}" is unknowm.`);

--- a/lib/js/components/basics.mjs
+++ b/lib/js/components/basics.mjs
@@ -13,6 +13,9 @@ import {
   , FreezableMap
 } from '../metamodel.mjs';
 
+import {
+    InjectDependency
+} from './dependency-injection.mjs';
 
  // To mark the update strategy of the widget
 export const UPDATE_STRATEGY_SIMPLE = Symbol('UPDATE_SIMPLE')
@@ -794,6 +797,17 @@ export class _CommonContainerComponent extends _BaseComponent {
         this._initWidgets(widgets);
     }
 
+    _applyDependencyInjection(parameter) {
+        if(!(parameter instanceof InjectDependency))
+            return parameter;
+
+        switch(parameter.name) {
+            case "zones":
+                return this._zones;
+        }
+        throw new Error(`KEY ERROR dependency injection parameter "${parameter.name}" is unknowm.`);
+    }
+
     _initWrapper(childrenWidgetBus, settings, dependencyMappings, Constructor, ...args) {
         const hostElement = settings.zone
             ? this._zones.get(settings.zone)
@@ -804,9 +818,10 @@ export class _CommonContainerComponent extends _BaseComponent {
                 + `found, available zones are: ${[...this._zones].map(([k,v])=>k + ':' + typeof v).join(', ')}. `
                 + `In ${this} for a ${Constructor.name}`);
         }
-        const widgetWrapper = new ComponentWrapper(childrenWidgetBus, dependencyMappings
+        const augmentedArgs = args.map(arg=>this._applyDependencyInjection(arg))
+          , widgetWrapper = new ComponentWrapper(childrenWidgetBus, dependencyMappings
                                     , {hostElement, ...settings}
-                                    , Constructor, ...args)
+                                    , Constructor, ...augmentedArgs)
           ;
         return widgetWrapper;
     }

--- a/lib/js/components/dependency-injection.mjs
+++ b/lib/js/components/dependency-injection.mjs
@@ -1,0 +1,31 @@
+/**
+ * This module ideally has very few dependencies, as it will be used a lot.
+ */
+
+export const _NOTDEF = Symbol('_NOTDEF');
+/**
+ * A parameter is the variable listed inside the parentheses in the
+ * function definition. An argument is the actual value that is sent
+ * to the function when it is called.
+ */
+export class InjectDependency {
+    constructor(name, payload=null, typeHint=_NOTDEF) {
+        this.name = name;
+        this.payload = payload;
+        // TODO: the same name can mean a totally different thing.
+        // We don't have real typing in here anyways, but this could be
+        // a place to help/instruct the caller to insert the right argument.
+        // This is just a stub, to suggest to a future me, that this could
+        // be a goog place to implement.
+        if(typeHint !== _NOTDEF)
+            throw new Error(`NOT IMPLEMENTED ${this.constructor.name} "typeHint" argument `
+                + `(value: ${typeHint.toString()}).`);
+    }
+    toString() {
+        return `[${this.constructor.name}: ${this.name}]`;
+    }
+}
+
+export function require(...args) {
+    return new InjectDependency(...args);
+}

--- a/lib/js/components/generic.mjs
+++ b/lib/js/components/generic.mjs
@@ -15,6 +15,7 @@ import{
 
 import {
     _BaseComponent
+  , _BaseContainerComponent
   // , UPDATE_STRATEGY
   // , UPDATE_STRATEGY_SIMPLE // jshint ignore: line
   , _UIAbstractPlainInputWrapper
@@ -952,14 +953,14 @@ export class Collapsible extends _BaseComponent {
         contentsElement?.classList.add(`${Collapsible.BASE_CLASS}-contents`);
         contentsElement?.setAttribute('aria-hidden', !isOpened);
         super(widgetBus);
-        
+
         element.append(togglerElement);
         element.append(contentsElement);
         this._insertElement(element);
         this._element = element;
         this._togglerElement = togglerElement;
         this._contentsElement = contentsElement;
-        
+
         togglerElement.textContent = togglerLabel;
         togglerElement.addEventListener('click', this._onClickToggler.bind(this))
     }
@@ -977,6 +978,96 @@ export class Collapsible extends _BaseComponent {
             this._element.classList.remove(Collapsible.OPENED_CLASS);
             this._element.classList.add(Collapsible.CLOSED_CLASS);
         }
+    }
+}
+
+/**
+ * All widgets are destroyed when collapsed and rebuild when expanded.
+ * Advantage of thuis approach is that the widgets are not updated when
+ * this is collapsed and this don't require any resources.
+ * Disadvantage is that widgets with ephemeral state will lose that state
+ * when collapsed. Persistent state, that goes into metamodel is of course
+ * preserved.
+ *
+ * We could maybe create a "safe haven" state in the ComponentWrapper to
+ * tackle this. We could also mark these widgets somehow, so they don't
+ * get destroyed and kept around instead, that would be more like a hybrid
+ * of CollapsibleContainer and Collapsible.
+ */
+export class CollapsibleContainer extends _BaseContainerComponent {
+    static BASE_CLASS = Collapsible.BASE_CLASS
+    static OPENED_CLASS = `${this.BASE_CLASS}-opened`;
+    static CLOSED_CLASS = `${this.BASE_CLASS}-closed`;
+
+    constructor(widgetBus, _zones, togglerLabel, classNameParticle, widgets=[], isOpened = false) {
+        const initialClasses = [
+                new.target.BASE_CLASS,
+              , isOpened ? new.target.OPENED_CLASS : new.target.CLOSED_CLASS
+              , `${new.target.BASE_CLASS}-${classNameParticle}`
+            ]
+          , togglerElement = widgetBus.domTool.createElement('div', {
+                    class: `${new.target.BASE_CLASS}-toggler`
+                  , role: 'button'
+                  , 'aria-expanded': isOpened
+                }
+              , togglerLabel
+            )
+          , contentsElement = widgetBus.domTool.createElement('div', {
+                class: `${classNameParticle} ${new.target.BASE_CLASS}-contents `
+                     + `${new.target.BASE_CLASS}-${classNameParticle}-contents`
+              , 'aria-hidden': !isOpened
+            })
+          , element = widgetBus.domTool.createElement('div', {
+                    class: initialClasses.join(' ')
+                }
+              , [togglerElement, contentsElement]
+            )
+          , zones = new Map([..._zones, ['main', contentsElement]])
+          ;
+        widgetBus.insertElement(element);
+        super(widgetBus, zones, widgets);
+        this._element = element;
+        this._togglerElement = togglerElement;
+        this._contentsElement = contentsElement;
+
+        togglerElement.textContent = togglerLabel;
+        togglerElement.addEventListener('click', this._onClickToggler.bind(this))
+    }
+
+    get isOpen() {
+        return this._togglerElement.getAttribute('aria-expanded') === 'true';
+    }
+
+    _onClickToggler() {
+        const isOpen = !this.isOpen;
+        this._togglerElement.setAttribute('aria-expanded', isOpen);
+        this._contentsElement.setAttribute('aria-hidden', !isOpen);
+        if (isOpen) {
+            this._element.classList.add(this.constructor.OPENED_CLASS);
+            this._element.classList.remove(this.constructor.CLOSED_CLASS);
+            this._element.scrollIntoView({block: 'start', inline: 'nearest', behavior: 'smooth'});
+        } else {
+            this._element.classList.remove(this.constructor.OPENED_CLASS);
+            this._element.classList.add(this.constructor.CLOSED_CLASS);
+        }
+        this._toggleWidgets();
+    }
+
+    _provisionWidgets(...args) {
+        if(!this.isOpen)
+            return new Set();
+        return super._provisionWidgets(...args);
+    }
+
+    _toggleWidgets() {
+        if(!this.isOpen) {
+            for(const widgetWrapper of this._widgets) {
+                this._destroyWidget(widgetWrapper);
+            }
+            return;
+        }
+        // will call _provisionWidgets
+        return this.initialUpdate(this.getEntry('/'));
     }
 }
 

--- a/lib/js/components/layouts/type-spec-ramp.typeroof.jsx
+++ b/lib/js/components/layouts/type-spec-ramp.typeroof.jsx
@@ -6705,7 +6705,7 @@ class TypeSpecRampController extends _BaseContainerComponent {
                         // should at this point just somehow get the parent zones
                         // injected!
                         // used to be: new Map([...zones, ["main", stylePatchesManagerContainer]]),
-                        require("zones"),
+                        require("raw:zones"),
                     ],
                 ],
             ],

--- a/lib/js/components/layouts/type-spec-ramp.typeroof.jsx
+++ b/lib/js/components/layouts/type-spec-ramp.typeroof.jsx
@@ -3,6 +3,8 @@
 
 import { identity, zip } from "../../util.mjs";
 
+import { require } from "../dependency-injection.mjs";
+
 import {
     _BaseComponent,
     _BaseContainerComponent,
@@ -17,6 +19,7 @@ import {
 
 import {
     Collapsible,
+    CollapsibleContainer,
     StaticNode,
     StaticTag,
     UILineOfTextInput,
@@ -6572,12 +6575,6 @@ class TypeSpecRampController extends _BaseContainerComponent {
                     class: "properties-manager",
                 },
             ),
-            stylePatchesManagerContainer = widgetBus.domTool.createElement(
-                "div",
-                {
-                    class: "style_patches-manager",
-                },
-            ),
             documentManagerContainer = widgetBus.domTool.createElement("div", {
                 class: "document-manager",
             }),
@@ -6588,7 +6585,6 @@ class TypeSpecRampController extends _BaseContainerComponent {
                 ..._zones,
                 ["type_spec-manager", typeSpecManagerContainer],
                 ["properties-manager", propertiesManagerContainer],
-                ["style_patches-manager", stylePatchesManagerContainer],
                 ["document-manager", documentManagerContainer],
                 ["node_spec-manager", nodeSpecManagerContainer],
             ]),
@@ -6653,9 +6649,65 @@ class TypeSpecRampController extends _BaseContainerComponent {
             [
                 { zone: "main" },
                 [],
-                Collapsible,
+                CollapsibleContainer,
+                zones,
                 "Styles",
-                stylePatchesManagerContainer,
+                "style_patches-manager",
+                [
+                    // widgets
+                    [
+                        {
+                            zone: "main",
+                            relativeRootPath: Path.fromParts(
+                                ".",
+                                "stylePatchesSource",
+                            ),
+                        },
+                        [
+                            [".", "childrenOrderedMap"],
+                            ["../editingStylePatch", "stylePatchPath"],
+                        ],
+                        UIStylePatchesMap, // search for e.g. UIAxesMathLocation in videoproof-array-v2.mjs
+                        zones,
+                        [], // eventHandlers
+                        null, // label 'Style Patches'
+                        true, // dragAndDrop
+                    ],
+                    [
+                        {
+                            zone: "main",
+                        },
+                        [["typeSpec/children", "rootCollection"]],
+                        WasteBasketDropTarget,
+                        "Delete",
+                        "", //'drag and drop into trash-bin.'
+                        [
+                            DATA_TRANSFER_TYPES.TYPE_SPEC_STYLE_PATCH_PATH,
+                            DATA_TRANSFER_TYPES.TYPE_SPEC_STYLE_PATCH_LINK_PATH,
+                            // to delete the axesLocations values coming from UIAxesMathLocation
+                            DATA_TRANSFER_TYPES.AXESMATH_LOCATION_VALUE_PATH,
+                        ],
+                    ],
+                    [
+                        {
+                            zone: "main",
+                            relativeRootPath: Path.fromParts(
+                                ".",
+                                "stylePatchesSource",
+                            ),
+                        },
+                        [
+                            [".", "childrenOrderedMap"],
+                            ["../editingStylePatch", "stylePatchPath"],
+                        ],
+                        StylePatchPropertiesManager,
+                        // This is hard! the zones of the parent are not yet created
+                        // should at this point just somehow get the parent zones
+                        // injected!
+                        // used to be: new Map([...zones, ["main", stylePatchesManagerContainer]]),
+                        require("zones"),
+                    ],
+                ],
             ],
             [
                 { zone: "main" },
@@ -6720,48 +6772,6 @@ class TypeSpecRampController extends _BaseContainerComponent {
                 ],
                 TypeSpecPropertiesManager,
                 new Map([...zones, ["main", propertiesManagerContainer]]),
-            ],
-            [
-                {
-                    zone: "style_patches-manager",
-                    relativeRootPath: Path.fromParts(".", "stylePatchesSource"),
-                },
-                [
-                    [".", "childrenOrderedMap"],
-                    ["../editingStylePatch", "stylePatchPath"],
-                ],
-                UIStylePatchesMap, // search for e.g. UIAxesMathLocation in videoproof-array-v2.mjs
-                zones,
-                [], // eventHandlers
-                null, // label 'Style Patches'
-                true, // dragAndDrop
-            ],
-            [
-                {
-                    zone: "style_patches-manager",
-                },
-                [["typeSpec/children", "rootCollection"]],
-                WasteBasketDropTarget,
-                "Delete",
-                "", //'drag and drop into trash-bin.'
-                [
-                    DATA_TRANSFER_TYPES.TYPE_SPEC_STYLE_PATCH_PATH,
-                    DATA_TRANSFER_TYPES.TYPE_SPEC_STYLE_PATCH_LINK_PATH,
-                    // to delete the axesLocations values coming from UIAxesMathLocation
-                    DATA_TRANSFER_TYPES.AXESMATH_LOCATION_VALUE_PATH,
-                ],
-            ],
-            [
-                {
-                    zone: "style_patches-manager",
-                    relativeRootPath: Path.fromParts(".", "stylePatchesSource"),
-                },
-                [
-                    [".", "childrenOrderedMap"],
-                    ["../editingStylePatch", "stylePatchPath"],
-                ],
-                StylePatchPropertiesManager,
-                new Map([...zones, ["main", stylePatchesManagerContainer]]),
             ],
             //  , [
             //        {

--- a/lib/js/components/type-driven-ui-basics.mjs
+++ b/lib/js/components/type-driven-ui-basics.mjs
@@ -128,6 +128,9 @@ export class _BaseTypeDrivenContainerComponent extends _BaseContainerComponent {
                 // CAUTION: settings.zone must be set
                 argument = new Map([...this._zones.entries(), ['main', this._zones.get(zone)]]);
                 break;
+            case "raw:zones":
+                argument = this._zones
+                break;
             // especially: getDefault and requireUpdateDefaults are
             // added requirements with _UIAbstractPlainOrEmptyInputWrapper
             // so far: defaultValue === BaseModelType.defaultValue

--- a/lib/js/components/type-driven-ui-basics.mjs
+++ b/lib/js/components/type-driven-ui-basics.mjs
@@ -34,7 +34,17 @@ import {
    , getLineWidthLeadingPPSMap
 } from './type-spec-models.mjs';
 
-export const _NOTDEF = Symbol('_NOTDEF');
+import {
+    _NOTDEF
+  , InjectDependency
+  , require
+} from './dependency-injection.mjs';
+
+export {
+    _NOTDEF
+  , InjectDependency
+  , require
+}
 
 export class UIMissingUIElement extends _BaseComponent {
     [UPDATE_STRATEGY] = UPDATE_STRATEGY_NO_UPDATE // jshint ignore:line
@@ -58,33 +68,6 @@ export class UIMissingUIElement extends _BaseComponent {
         this._insertElement(element);
         return [element];
     }
-}
-
-/**
- * A parameter is the variable listed inside the parentheses in the
- * function definition. An argument is the actual value that is sent
- * to the function when it is called.
- */
-export class InjectDependency {
-    constructor(name, payload=null, typeHint=_NOTDEF) {
-        this.name = name;
-        this.payload = payload;
-        // TODO: the same name can mean a totally different thing.
-        // We don't have real typing in here anyways, but this could be
-        // a place to help/instruct the caller to insert the right argument.
-        // This is just a stub, to suggest to a future me, that this could
-        // be a goog place to implement.
-        if(typeHint !== _NOTDEF)
-            throw new Error(`NOT IMPLEMENTED ${this.constructor.name} "typeHint" argument `
-                + `(value: ${typeHint.toString()}).`);
-    }
-    toString(){
-        return `[${this.constructor.name}: ${this.name}]`;
-    }
-}
-
-export function require(...args) {
-    return new InjectDependency(...args);
 }
 
 export class _BaseTypeDrivenContainerComponent extends _BaseContainerComponent {


### PR DESCRIPTION
@eomine Here's the component we talked about in https://github.com/FontBureau/TypeRoof/pull/55#issuecomment-3446552189

I used it only in one case as a demo: the `Styles` menu in `type-spec-ramp`.

I added a discussion of the advantages/disadvantages as a comment and into the commit messages.

In order to configure `StylePatchPropertiesManager`, which requires a `zones` map, I had to defer the resolution of the argument, as the `zones` map to use is not available at that point in time. I reused some of the dependency-injection marker items from `type-driven-ui-basics`, I'm quite happy with that, as I have future plans to automatically configure widgets and this gives me another case to look at. It is also already in use in the `type-driven` system. However, I'm not sure how much of `type-driven` will endure the test of time.

I also tried to keep the commits separate as distinguished steps, to make it easier to comprehend.