### PR TITLE
Show language tag details in tooltips

### DIFF
--- a/lib/css/shell/main.css
+++ b/lib/css/shell/main.css
@@ -862,7 +862,7 @@ ui plain select
     align-items: center;
     display: flex;
     gap: 0.25em;
-    padding: 1em 0;
+    padding: 0.25em 0;
 
     label {
         width: 35%;

--- a/lib/css/shell/main.css
+++ b/lib/css/shell/main.css
@@ -1968,6 +1968,21 @@ dimension sequence
     padding: 0.3em;
 }
 
+.ui_language_subtag_input {
+    align-items: center;
+    display: flex;
+    gap: var(--gap-size);
+    padding: 0.25em 0;
+
+    > label {
+        width: 25%;
+    }
+
+    > input {
+        width: 20%;
+    }
+}
+
 .ui_language_subtag_info ~ .ui_language_subtag_info {
     padding-block-start: 1.3em;
 }
@@ -2002,3 +2017,26 @@ dimension sequence
         content: ", ";
     }
 }
+
+/******************************************************************************
+tooltips
+*******************************************************************************/
+
+.ui_tooltip_trigger {
+    cursor: pointer;
+}
+
+.ui_tooltip {
+    inset: unset;
+    position: absolute;
+    /* stylelint-disable-next-line declaration-property-value-no-unknown */
+    align-self: anchor-center;
+    left: calc(anchor(right) + 5px);
+    margin: 0;
+    padding: 1em;
+    background-color: var(--tooltip-bg-color);
+    border: 0;
+    color: var(--tooltip-text-color);
+}
+
+/**************************************************************************** */

--- a/lib/css/shell/variables.css
+++ b/lib/css/shell/variables.css
@@ -32,4 +32,6 @@
     --menu-button-bg-color-hover: #eee;
     --sidebar-bg-color: #eee;
     --parameters-label-color: #09f; /* blue is the color of engineering */
+    --tooltip-bg-color: #000c;
+    --tooltip-text-color: #fff;
 }

--- a/lib/js/components/basics.mjs
+++ b/lib/js/components/basics.mjs
@@ -3399,3 +3399,18 @@ export class _UIAbstractPlainOrEmptyInputWrapper extends _BaseComponent {
         }
     }
 }
+
+export function setupTooltip(element) {
+    const trigger = element.querySelector(".ui_tooltip_trigger");
+    const tooltip = element.querySelector(".ui_tooltip");
+    const showTooltip = () => {
+        tooltip.showPopover({ source: trigger });
+    };
+    const hideTooltip = () => {
+        tooltip.hidePopover();
+    };
+    trigger.addEventListener("mouseover", showTooltip);
+    trigger.addEventListener("mouseout", hideTooltip);
+    trigger.addEventListener("focus", showTooltip);
+    trigger.addEventListener("blur", hideTooltip);
+}

--- a/lib/js/components/layouts/type-spec-ramp.typeroof.jsx
+++ b/lib/js/components/layouts/type-spec-ramp.typeroof.jsx
@@ -1163,7 +1163,7 @@ class TypeSpecPropertiesManager extends _CommonContainerComponent {
                 "h3",
                 {},
                 (typeSpecPath.equals(rootTypeSpecPath) ? "Origin " : "") +
-                    `Type-Spec:`,
+                    `TypeSpec`,
             ],
             [
                 {
@@ -1267,7 +1267,7 @@ class TypeSpecPropertiesManager extends _CommonContainerComponent {
                     // This is probably not required for the CommonActorProperties at all.
                 ],
                 UIshowProcessedProperties,
-                "Type-Spec",
+                "TypeSpec",
             ],
         ];
         // this._initWrapper(this._childrenWidgetBus, settings, dependencyMappings, Constructor, ...args);

--- a/lib/js/components/type-spec-fundamentals.mjs
+++ b/lib/js/components/type-spec-fundamentals.mjs
@@ -1046,7 +1046,7 @@ export class UINodeSpecToTypeSpecLinksMap extends _UIBaseMap {
                 ]
               , LinksMapKeyCreateSelect
               , 'ui_links_map-create_select'// baseClass
-              , ' with a Type-Spec'// labelContent
+              , ' with a TypeSpec'// labelContent
               , typeSpecGetOptionLabel// optionGetLabel=null || optionGetLabel(key, value)=>label
               , []// [true, EMPTY_TYPESPEC_LINK_LABEL]// allowNull: [allowNull, allowNullLabel, nullModelValue]
                 // As a suggestion, it makes sense to re-use the

--- a/lib/js/components/type-spec-models.mjs
+++ b/lib/js/components/type-spec-models.mjs
@@ -199,7 +199,6 @@ const typographyKeyMomentPureModelMixin = [
         // font-size should be in EM, but we don't do units yet
         ...typographyKeyMomentPureModelMixin
       , ...openTypeFeaturesModelMixin
-      , ...languageTagModelMixin
     ]
     // in EN
   , ColumnWidthModel = _AbstractNumberModel.createClass('ColumnWidthModel', {min:0, /*max:160,*/ defaultValue: 40, toFixedDigits: 1})
@@ -244,6 +243,7 @@ export const StylePatchTypeModel = _AbstractGenericModel.createClass('StylePatch
   , AvailableStylePatchTypesModel = _AbstractOrderedMapModel.createClass('AvailableStylePatchTypesModel', AvailableStylePatchTypeModel)
   , SimpleStylePatchModel = _BaseStylePatchModel.createClass(
         'SimpleStylePatchModel'
+      , ...languageTagModelMixin
         // There's no reason to put these under another key
         // TypeSpec and this should use the same mixin, as the shared
         // definitions are the ones that can be overridden by a patch.
@@ -343,6 +343,7 @@ export const StylePatchTypeModel = _AbstractGenericModel.createClass('StylePatch
     // , TypeSpecMap = _AbstractOrderedMapModel.createClass('TypeSpecMap', TypeSpec)
   , TypeSpecModel = _AbstractStructModel.createClass(
         'TypeSpec'
+      , ...languageTagModelMixin
       , ...typographyParagraphMixin // there's no reason to put these under another key
       , ...typographyInlineMixin
       , ...manualAxesLocationsModelMixin

--- a/shell.html
+++ b/shell.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="initial-scale=1,shrink-to-fit=no">
         <script src="./lib/js/main-shell.mjs" async type="module"></script>
         <link rel="stylesheet" href="./lib/css/shell/main.css">
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=add,arrow_forward,chevron_right,delete,drag_pan,format_align_center,format_align_left,format_align_right,keyboard_arrow_down,keyboard_arrow_up,keyboard_double_arrow_left,keyboard_double_arrow_right,menu,pause,place_item,play_arrow,refresh,remove,swap_vert" />
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=add,arrow_forward,chevron_right,delete,drag_pan,format_align_center,format_align_left,format_align_right,info,keyboard_arrow_down,keyboard_arrow_up,keyboard_double_arrow_left,keyboard_double_arrow_right,menu,pause,place_item,play_arrow,refresh,remove,swap_vert" />
 <script>
     // With this pattern it's save to load the controller javascript asyncronously.
     if(!window.remoteResources)


### PR DESCRIPTION
Use the new [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) to implement tooltips (currently supported by [~87%](https://caniuse.com/mdn-api_htmlelement_popover) of users).

Note: I was able to move the "Language" section up, but below "Origin TypeSpec". Moving it to the topmost position will require a larger refactoring.

Next step: adjusting the spacing between sections inside "TypeSpec Properties", i.e., adding space before the "Language", "Vertical Margins", "OpenType Features", "Manual Axes Locations" headings, and grouping the "Column Width" and "Leading Algorithm" fields.