### PR TITLE
Fix bug with axis name tooltips

### DIFF
--- a/lib/js/components/basics.mjs
+++ b/lib/js/components/basics.mjs
@@ -3402,6 +3402,8 @@ export class _UIAbstractPlainOrEmptyInputWrapper extends _BaseComponent {
 
 export function setupTooltip(element) {
     const trigger = element.querySelector(".ui_tooltip_trigger");
+    if (!trigger) return;
+
     const tooltip = element.querySelector(".ui_tooltip");
     const showTooltip = () => {
         tooltip.showPopover({ source: trigger });

--- a/lib/js/components/ui-manual-axis-locations.mjs
+++ b/lib/js/components/ui-manual-axis-locations.mjs
@@ -492,6 +492,7 @@ export class UIManualAxesLocations extends _BaseComponent {
                 }
             }
 
+            const showAxisNameTooltip = name !== axisTag;
             const input = new PlainNumberAndRangeOrEmptyInput(
                 this._domTool
                 // numberChangeHandler
@@ -508,7 +509,7 @@ export class UIManualAxesLocations extends _BaseComponent {
                         ;
                     this._axisChangeHandler(axisTag, value);
                 }
-              , name !== axisTag ? new HTMLString(`
+              , showAxisNameTooltip ? new HTMLString(`
                     <abbr class="ui_tooltip_trigger">
                         ${axisTag}
                     </abbr>
@@ -520,7 +521,9 @@ export class UIManualAxesLocations extends _BaseComponent {
               , {min, max, /*step,*/ value: defaultVal}
             );
 
-            setupTooltip(input.element);
+            if (showAxisNameTooltip) {
+                setupTooltip(input.element);
+            }
             insertElement(input.element);
             // insert after the element
             if(axisTag === 'opsz')


### PR DESCRIPTION
The latest PR introduced a bug when selecting some fonts (e.g., Amstelvar) which don't have full names for some axes.
This PR fixes that bug.