### PR TITLE
Feature/videoproof contextual

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -22,6 +22,7 @@
 !lib/js/**/*.css
 !**/ramp/*.*
 !lib/js/components/**/videoproof-contextual/*
+!lib/js/components/presets.mjs
 
 # Ignore glyph-groups.yaml
 lib/assets/glyph-groups.yaml

--- a/lib/css/shell/main.css
+++ b/lib/css/shell/main.css
@@ -1263,42 +1263,6 @@ select and drag
     display: inline;
 }
 
-/*
- * hide
- *    - output: when focused
- *    - inputs: when not focused (by default)
- */
-.ui-axes_math-location_value:focus-within .ui-axes_math-location_value-output,
-.ui-axes_math-location_value-drag_handle,
-.ui-axes_math-location_value .ui-axes_math-location_value-logical_value,
-.ui-axes_math-location_value .ui-axes_math-location_value-numeric_value,
-.ui-axes_math-location_value.dragging
-    .ui-axes_math-location_value-logical_value,
-.ui-axes_math-location_value.dragging
-    .ui-axes_math-location_value-numeric_value,
-.ui-axes_math-location_value:focus-within.dragging
-    .ui-axes_math-location_value-logical_value,
-.ui-axes_math-location_value:focus-within.dragging
-    .ui-axes_math-location_value-numeric_value {
-    display: none;
-}
-
-/*
- * show
- *    - output: when not focused (default)
- *    - inputs: when focused
- */
-.ui-axes_math-location_value:focus-within
-    .ui-axes_math-location_value-logical_value,
-.ui-axes_math-location_value:focus-within
-    .ui-axes_math-location_value-numeric_value,
-.ui-axes_math-location_value:focus-within
-    .ui-axes_math-location_value-drag_handle,
-.ui-axes_math-location_value.dragging .ui-axes_math-location_value-output,
-.ui-axes_math-location_value.dragging .ui-axes_math-location_value-drag_handle {
-    display: initial;
-}
-
 .ui-axes_math-location_value-numeric_value {
     width: calc(5 * 0.75em);
 }

--- a/lib/js/components/actors/videoproof-contextual/models.mjs
+++ b/lib/js/components/actors/videoproof-contextual/models.mjs
@@ -193,17 +193,17 @@ export const TemplateRuleModel = _AbstractStructModel.createClass(
 //   - auto-long:  Latin lowercase → 'nn\1nono\1oo', figures → '00\10101\111', default 'HH\1HOHO\1OO', \1 = current, \2 = none
 //   - kern-upper: default 'HO\1\2\1OLA', \1=Latin.Uppercase, \2=same
 //   - kern-mixed: default '\1\2nnoy', \1=Latin.Uppercase \2=Latin.Lowercase,
-//   - kern-lower: default 'no\1\2\1ony', \1r=Latin.Lowercase, \2=same
+//   - kern-lower: default 'no\1\2\1ony', \1=Latin.Lowercase, \2=same
 const PRESETS_OPTIONS = new Map([
         [
             "auto-short",
             {
                 // Legacy behavior is leave as it is (using "selectedChars") ...
-                // And it seems like that is working niceley, the
+                // And it seems like that is working nicely, the
                 // charGroups, as not set by the coherence function,
                 // are not marked to be skipped by serialization and are
                 // serialized, while the template is skipped and reconstructed
-                // from the serialzied data in the presets
+                // from the serialized data in the presets
                 // charGroups: [{ options: "all-gid" }],
                 template: {
                     rules: [

--- a/lib/js/components/actors/videoproof-contextual/models.mjs
+++ b/lib/js/components/actors/videoproof-contextual/models.mjs
@@ -25,10 +25,6 @@ import {
     createAvailableTypes,
     createDynamicType,
     StaticDependency,
-    unwrapPotentialWriteProxy,
-    deserializeSync,
-    SERIALIZE_OPTIONS,
-    SERIALIZE_FORMAT_OBJECT,
 } from "../../../metamodel.mjs";
 
 import {
@@ -43,6 +39,8 @@ import { _BaseActorModel, genericActorMixin } from "../actors-base.mjs";
 import { ColorModel } from "../../color.mjs";
 
 import { CharGroupModel } from "../videoproof-array.mjs";
+
+import { applyPresets, CUSTOM_PRESET_KEY } from "../../presets.mjs";
 
 // Coherence: ensure charGroups has 1-2 items
 function ensureAtLeastOneCharGroup({ charGroups }) {
@@ -196,8 +194,7 @@ export const TemplateRuleModel = _AbstractStructModel.createClass(
 //   - kern-upper: default 'HO\1\2\1OLA', \1=Latin.Uppercase, \2=same
 //   - kern-mixed: default '\1\2nnoy', \1=Latin.Uppercase \2=Latin.Lowercase,
 //   - kern-lower: default 'no\1\2\1ony', \1r=Latin.Lowercase, \2=same
-const CUSTOM_PRESET_KEY = "custom",
-    PRESETS_OPTIONS = new Map([
+const PRESETS_OPTIONS = new Map([
         [
             "auto-short",
             {
@@ -303,142 +300,42 @@ const CUSTOM_PRESET_KEY = "custom",
         ],
         [CUSTOM_PRESET_KEY, null],
     ]),
-    _presets_options_keys = Array.from(PRESETS_OPTIONS.keys()),
-    ContextualPresetModel = _AbstractEnumModel.createClass(
+    _presets_options_keys = Array.from(PRESETS_OPTIONS.keys());
+export const ContextualPresetModel = _AbstractEnumModel.createClass(
         "ContextualPresetModel",
         _presets_options_keys,
         _presets_options_keys.at(0),
     ),
-    GENERATED_DATA = Symbol.for("GENERATED_DATA");
-
-function copyToDraft(item) {
-    const draftItem = item.constructor.createPrimalDraft(item.dependencies);
-    for (const [key, entry] of item) {
-        if (item instanceof _AbstractListModel) draftItem.push(entry);
-        else draftItem.set(key, entry);
-    }
-    return draftItem;
-}
-
-/**
- * By injecting PRESETS_OPTIONS and CUSTOM_PRESET_KEY I hope this can
- * be used as a pattern for other preset implementations as well!
- */
-function applyPresets(
-    presetsFieldName,
-    PRESETS_OPTIONS,
-    CUSTOM_PRESET_KEY,
-    valuesMap,
-    { isNew /*, wasSerialized*/, setFn },
-) {
-    const {
-        [presetsFieldName]: presets,
-        ...settables // {charGroups, template}}
-    } = valuesMap;
-
-    // - If any item of settables is customized the presets.value
-    //   should become CUSTOM_PRESET_KEY ("custom") as well.
-    // - When the type has changed to a not "custom" key, the
-    //  settables must be changed as well.
-    //
-    // The idea is that the GENERATED_DATA symbol will
-    // disappear when edited outside of this function
-    // and hence we would set the type to "custom"
-
-    const presetsChanged = !!unwrapPotentialWriteProxy(presets, "draft");
-
-    let apply = "";
-    if (presets.value !== CUSTOM_PRESET_KEY && (isNew || presetsChanged)) {
-        // isNew: wouldn't have the data applied
-        // presetsChanged: whatever the data is now, it will be replaced
-        apply = "preset";
-    } else if (presets.value === CUSTOM_PRESET_KEY && presetsChanged) {
-        apply = CUSTOM_PRESET_KEY;
-    } else {
-        const presetData = PRESETS_OPTIONS.get(presets.value);
-        for (const [key, entry] of Object.entries(settables)) {
-            // depending on the presence in the presets we skip the entry here!
-            // i.e. if charGroups is settable, but the current preset doesn't
-            // set it, it can't trigger apply(CUSTOM_PRESET_KEY).
-            if (presetData && !(key in presetData)) continue;
-            const unwrapped = unwrapPotentialWriteProxy(entry);
-            if (!Object.hasOwn(unwrapped, GENERATED_DATA)) {
-                // entry has been customized/not generated/created in here.
-                apply = CUSTOM_PRESET_KEY;
-                presets.value = CUSTOM_PRESET_KEY;
-                break;
-            }
-        }
-    }
-    // apply a state if required...
-    if (apply === "preset") {
-        const serializeOptions = Object.assign({}, SERIALIZE_OPTIONS, {
-                format: SERIALIZE_FORMAT_OBJECT,
-            }),
-            presetData = PRESETS_OPTIONS.get(presets.value);
-        for (const [key, entry] of Object.entries(settables)) {
-            if (!(key in presetData)) continue;
-            const Ctor = unwrapPotentialWriteProxy(entry).constructor,
-                serializedData = presetData[key],
-                newEntry = deserializeSync(
-                    Ctor,
-                    entry.dependencies,
-                    serializedData,
-                    serializeOptions,
-                );
-            // the new Entry is immutable and we need it to
-            // be a draft with actual changes so the GENERATED_DATA
-            // flag sticks to it...
-            const entryDraft = copyToDraft(newEntry);
-            // Actually the mere presence of this GENERATED_DATA
-            // symbol is enough, the value may be helping when debugging.
-            entryDraft[GENERATED_DATA] = presets.value;
-            setFn(key, entryDraft);
-        }
-    } else if (apply === CUSTOM_PRESET_KEY) {
-        // The data will have to be serialized.
-        // Make sure the drafts are going to be new items
-        // and not reverted back, so that the GENERATED_DATA
-        // symbol cannot stick! Create a copy:
-        for (const [key, entry] of Object.entries(settables)) {
-            const newEntry = copyToDraft(entry); // => new item
-            // this should have deleted any trace of GENERATED_DATA
-            setFn(key, newEntry);
-        }
-    }
-}
-
-export const VideoproofContextualKeyMomentModel =
-        _AbstractStructModel.createClass(
-            "VideoproofContextualKeyMomentModel",
-            ...typographyKeyMomentModelMixin,
-            // TODO: when we are going for dynamically loaded, user-defined
-            // presets this may have to change. It could still be driven
-            // by that enum, e.g. adding a "user" option, but the value
-            // for the user defined option would be a string database key
-            // or so.
-            ["presets", ContextualPresetModel],
-            ["charGroups", CharGroupArgumentsListModel],
-            ["template", TemplateModel],
-            ["stageBackgroundColor", ColorModel],
-            CoherenceFunction.create(
-                ["presets", "charGroups", "template"],
-                applyPresets.bind(
-                    null,
-                    "presets",
-                    PRESETS_OPTIONS,
-                    CUSTOM_PRESET_KEY,
-                ),
-            ),
-            // These run after the presets to ensure **coherence**.
-            CoherenceFunction.create(["charGroups"], ensureAtLeastOneCharGroup),
-            CoherenceFunction.create(
-                ["charGroups"],
-                function capCharGroupsAtTwo({ charGroups }) {
-                    if (charGroups.size > 2) charGroups.splice(2, Infinity);
-                },
+    VideoproofContextualKeyMomentModel = _AbstractStructModel.createClass(
+        "VideoproofContextualKeyMomentModel",
+        ...typographyKeyMomentModelMixin,
+        // TODO: when we are going for dynamically loaded, user-defined
+        // presets this may have to change. It could still be driven
+        // by that enum, e.g. adding a "user" option, but the value
+        // for the user defined option would be a string database key
+        // or so.
+        ["presets", ContextualPresetModel],
+        ["charGroups", CharGroupArgumentsListModel],
+        ["template", TemplateModel],
+        ["stageBackgroundColor", ColorModel],
+        CoherenceFunction.create(
+            ["presets", "charGroups", "template"],
+            applyPresets.bind(
+                null,
+                "presets",
+                PRESETS_OPTIONS,
+                CUSTOM_PRESET_KEY,
             ),
         ),
+        // These run after the presets to ensure **coherence**.
+        CoherenceFunction.create(["charGroups"], ensureAtLeastOneCharGroup),
+        CoherenceFunction.create(
+            ["charGroups"],
+            function capCharGroupsAtTwo({ charGroups }) {
+                if (charGroups.size > 2) charGroups.splice(2, Infinity);
+            },
+        ),
+    ),
     VideoproofContextualKeyMomentsModel = _AbstractListModel.createClass(
         "VideoproofContextualKeyMomentsModel",
         VideoproofContextualKeyMomentModel,

--- a/lib/js/components/actors/videoproof-contextual/models.mjs
+++ b/lib/js/components/actors/videoproof-contextual/models.mjs
@@ -25,6 +25,10 @@ import {
     createAvailableTypes,
     createDynamicType,
     StaticDependency,
+    unwrapPotentialWriteProxy,
+    deserializeSync,
+    SERIALIZE_OPTIONS,
+    SERIALIZE_FORMAT_OBJECT,
 } from "../../../metamodel.mjs";
 
 import {
@@ -187,18 +191,251 @@ export const TemplateRuleModel = _AbstractStructModel.createClass(
 
 // --- Actor Model ---
 
+//   - auto-short: Latin lowercase → 'nn\1nn', figures → '00\100', default 'HH\1HH', \1 = current, \2 = none
+//   - auto-long:  Latin lowercase → 'nn\1nono\1oo', figures → '00\10101\111', default 'HH\1HOHO\1OO', \1 = current, \2 = none
+//   - kern-upper: default 'HO\1\2\1OLA', \1=Latin.Uppercase, \2=same
+//   - kern-mixed: default '\1\2nnoy', \1=Latin.Uppercase \2=Latin.Lowercase,
+//   - kern-lower: default 'no\1\2\1ony', \1r=Latin.Lowercase, \2=same
+const CUSTOM_PRESET_KEY = "custom",
+    PRESETS_OPTIONS = new Map([
+        [
+            "auto-short",
+            {
+                // Legacy behavior is leave as it is (using "selectedChars") ...
+                // And it seems like that is working niceley, the
+                // charGroups, as not set by the coherence function,
+                // are not marked to be skipped by serialization and are
+                // serialized, while the template is skipped and reconstructed
+                // from the serialzied data in the presets
+                // charGroups: [{ options: "all-gid" }],
+                template: {
+                    rules: [
+                        {
+                            selector: {
+                                instance: {
+                                    argIndex: "0",
+                                    charGroup: {
+                                        options: "World.Figures",
+                                        extended: "1",
+                                    },
+                                },
+                                selectorTypeKey: "Simple",
+                            },
+                            pattern: "00\\100",
+                        },
+                        {
+                            selector: {
+                                instance: {
+                                    argIndex: "0",
+                                    charGroup: {
+                                        options: "Latin.Lowercase",
+                                        extended: "1",
+                                    },
+                                },
+                                selectorTypeKey: "Simple",
+                            },
+                            pattern: "nn\\1nn",
+                        },
+                    ],
+                    defaultPattern: "HH\\1HH",
+                },
+            },
+        ],
+        [
+            "auto-long",
+            {
+                template: {
+                    rules: [
+                        {
+                            selector: {
+                                instance: {
+                                    argIndex: "0",
+                                    charGroup: {
+                                        options: "World.Figures",
+                                        extended: "1",
+                                    },
+                                },
+                                selectorTypeKey: "Simple",
+                            },
+                            pattern: "00\\10101\\111",
+                        },
+                        {
+                            selector: {
+                                instance: {
+                                    argIndex: "0",
+                                    charGroup: {
+                                        options: "Latin.Lowercase",
+                                        extended: "1",
+                                    },
+                                },
+                                selectorTypeKey: "Simple",
+                            },
+                            pattern: "nn\\1nono\\1oo",
+                        },
+                    ],
+                    defaultPattern: "HH\\1HOHO\\1OO",
+                },
+            },
+        ],
+        [
+            "kern-upper",
+            {
+                charGroups: [{ options: "Latin.Uppercase" }],
+                template: { defaultPattern: "HO\\1\\2\\1OLA" },
+            },
+        ],
+        [
+            "kern-mixed",
+            {
+                charGroups: [
+                    { options: "Latin.Uppercase" },
+                    { options: "Latin.Lowercase" },
+                ],
+                template: { defaultPattern: "\\1\\2nnoy" },
+            },
+        ],
+        [
+            "kern-lower",
+            {
+                charGroups: [{ options: "Latin.Lowercase" }],
+                template: { defaultPattern: "no\\1\\2\\1ony" },
+            },
+        ],
+        [CUSTOM_PRESET_KEY, null],
+    ]),
+    _presets_options_keys = Array.from(PRESETS_OPTIONS.keys()),
+    ContextualPresetModel = _AbstractEnumModel.createClass(
+        "ContextualPresetModel",
+        _presets_options_keys,
+        _presets_options_keys.at(0),
+    ),
+    GENERATED_DATA = Symbol.for("GENERATED_DATA");
+
+function copyToDraft(item) {
+    const draftItem = item.constructor.createPrimalDraft(item.dependencies);
+    for (const [key, entry] of item) {
+        if (item instanceof _AbstractListModel) draftItem.push(entry);
+        else draftItem.set(key, entry);
+    }
+    return draftItem;
+}
+
+/**
+ * By injecting PRESETS_OPTIONS and CUSTOM_PRESET_KEY I hope this can
+ * be used as a pattern for other preset implementations as well!
+ */
+function applyPresets(
+    presetsFieldName,
+    PRESETS_OPTIONS,
+    CUSTOM_PRESET_KEY,
+    valuesMap,
+    { isNew /*, wasSerialized*/, setFn },
+) {
+    const {
+        [presetsFieldName]: presets,
+        ...settables // {charGroups, template}}
+    } = valuesMap;
+
+    // - If any item of settables is customized the presets.value
+    //   should become CUSTOM_PRESET_KEY ("custom") as well.
+    // - When the type has changed to a not "custom" key, the
+    //  settables must be changed as well.
+    //
+    // The idea is that the GENERATED_DATA symbol will
+    // disappear when edited outside of this function
+    // and hence we would set the type to "custom"
+
+    const presetsChanged = !!unwrapPotentialWriteProxy(presets, "draft");
+
+    let apply = "";
+    if (presets.value !== CUSTOM_PRESET_KEY && (isNew || presetsChanged)) {
+        // isNew: wouldn't have the data applied
+        // presetsChanged: whatever the data is now, it will be replaced
+        apply = "preset";
+    } else if (presets.value === CUSTOM_PRESET_KEY && presetsChanged) {
+        apply = CUSTOM_PRESET_KEY;
+    } else {
+        const presetData = PRESETS_OPTIONS.get(presets.value);
+        for (const [key, entry] of Object.entries(settables)) {
+            // depending on the presence in the presets we skip the entry here!
+            // i.e. if charGroups is settable, but the current preset doesn't
+            // set it, it can't trigger apply(CUSTOM_PRESET_KEY).
+            if (presetData && !(key in presetData)) continue;
+            const unwrapped = unwrapPotentialWriteProxy(entry);
+            if (!Object.hasOwn(unwrapped, GENERATED_DATA)) {
+                // entry has been customized/not generated/created in here.
+                apply = CUSTOM_PRESET_KEY;
+                presets.value = CUSTOM_PRESET_KEY;
+                break;
+            }
+        }
+    }
+    // apply a state if required...
+    if (apply === "preset") {
+        const serializeOptions = Object.assign({}, SERIALIZE_OPTIONS, {
+                format: SERIALIZE_FORMAT_OBJECT,
+            }),
+            presetData = PRESETS_OPTIONS.get(presets.value);
+        for (const [key, entry] of Object.entries(settables)) {
+            if (!(key in presetData)) continue;
+            const Ctor = unwrapPotentialWriteProxy(entry).constructor,
+                serializedData = presetData[key],
+                newEntry = deserializeSync(
+                    Ctor,
+                    entry.dependencies,
+                    serializedData,
+                    serializeOptions,
+                );
+            // the new Entry is immutable and we need it to
+            // be a draft with actual changes so the GENERATED_DATA
+            // flag sticks to it...
+            const entryDraft = copyToDraft(newEntry);
+            // Actually the mere presence of this GENERATED_DATA
+            // symbol is enough, the value may be helping when debugging.
+            entryDraft[GENERATED_DATA] = presets.value;
+            setFn(key, entryDraft);
+        }
+    } else if (apply === CUSTOM_PRESET_KEY) {
+        // The data will have to be serialized.
+        // Make sure the drafts are going to be new items
+        // and not reverted back, so that the GENERATED_DATA
+        // symbol cannot stick! Create a copy:
+        for (const [key, entry] of Object.entries(settables)) {
+            const newEntry = copyToDraft(entry); // => new item
+            // this should have deleted any trace of GENERATED_DATA
+            setFn(key, newEntry);
+        }
+    }
+}
+
 export const VideoproofContextualKeyMomentModel =
         _AbstractStructModel.createClass(
             "VideoproofContextualKeyMomentModel",
             ...typographyKeyMomentModelMixin,
+            // TODO: when we are going for dynamically loaded, user-defined
+            // presets this may have to change. It could still be driven
+            // by that enum, e.g. adding a "user" option, but the value
+            // for the user defined option would be a string database key
+            // or so.
+            ["presets", ContextualPresetModel],
             ["charGroups", CharGroupArgumentsListModel],
             ["template", TemplateModel],
             ["stageBackgroundColor", ColorModel],
+            CoherenceFunction.create(
+                ["presets", "charGroups", "template"],
+                applyPresets.bind(
+                    null,
+                    "presets",
+                    PRESETS_OPTIONS,
+                    CUSTOM_PRESET_KEY,
+                ),
+            ),
+            // These run after the presets to ensure **coherence**.
             CoherenceFunction.create(["charGroups"], ensureAtLeastOneCharGroup),
             CoherenceFunction.create(
                 ["charGroups"],
                 function capCharGroupsAtTwo({ charGroups }) {
-                    charGroups.splice(2, Infinity);
+                    if (charGroups.size > 2) charGroups.splice(2, Infinity);
                 },
             ),
         ),

--- a/lib/js/components/actors/videoproof-contextual/template.mjs
+++ b/lib/js/components/actors/videoproof-contextual/template.mjs
@@ -367,19 +367,3 @@ export function generateWords(compiledTemplate, innerChars, outerChars = null) {
     }
     return words;
 }
-
-// --- Built-in Template Presets ---
-//
-// TODO: Fill with actual serialized TemplateModel data (from metamodel
-// deserialization). The built-in templates should be proper TemplateModel
-// instances, not an ad-hoc format. Use the TemplateModel deserialize API
-// to create them.
-//
-// Templates to define (replicating current pad modes):
-//   - auto-short: Latin lowercase → 'nn\1nn', figures → '00\100', default 'HH\1HH'
-//   - auto-long:  Latin lowercase → 'nn\1nono\1oo', figures → '00\10101\111', default 'HH\1HOHO\1OO'
-//   - kern-upper: default 'HO\1\2\1OLA', inner=Latin.Uppercase, outer=same
-//   - kern-mixed: default '\1\2nnoy', inner=Latin.Lowercase, outer=Latin.Uppercase
-//   - kern-lower: default 'no\1\2\1ony', inner=Latin.Lowercase, outer=same
-//
-// export const BUILTIN_TEMPLATES = {};

--- a/lib/js/components/axes-math-location-value.css
+++ b/lib/js/components/axes-math-location-value.css
@@ -1,0 +1,42 @@
+/*
+ * Maybe incomplete, but this is the base of the functional CSS ensuring
+ * the focus driven UI works.
+ */
+
+
+/* Base: show output, hide controls */
+.ui-axes_math-location_value .ui-axes_math-location_value-logical_value,
+.ui-axes_math-location_value .ui-axes_math-location_value-numeric_value,
+.ui-axes_math-location_value .ui-axes_math-location_value-drag_handle {
+    display: none;
+}
+
+.ui-axes_math-location_value .ui-axes_math-location_value-output {
+    display: inline;
+}
+
+/* Focused: show controls, hide output */
+.ui-axes_math-location_value.focus .ui-axes_math-location_value-logical_value,
+.ui-axes_math-location_value.focus .ui-axes_math-location_value-numeric_value,
+.ui-axes_math-location_value.focus .ui-axes_math-location_value-drag_handle {
+    display: initial;
+}
+
+.ui-axes_math-location_value.focus .ui-axes_math-location_value-output {
+    display: none;
+}
+
+/* Dragging overrides */
+.ui-axes_math-location_value.dragging .ui-axes_math-location_value-output,
+.ui-axes_math-location_value.dragging .ui-axes_math-location_value-drag_handle {
+    display: initial;
+}
+
+.ui-axes_math-location_value.dragging .ui-axes_math-location_value-logical_value,
+.ui-axes_math-location_value.dragging .ui-axes_math-location_value-numeric_value {
+    display: none;
+}
+
+.ui-axes_math-location_value > * {
+    vertical-align: middle;
+}

--- a/lib/js/components/axes-math-location-value.css
+++ b/lib/js/components/axes-math-location-value.css
@@ -3,7 +3,6 @@
  * the focus driven UI works.
  */
 
-
 /* Base: show output, hide controls */
 .ui-axes_math-location_value .ui-axes_math-location_value-logical_value,
 .ui-axes_math-location_value .ui-axes_math-location_value-numeric_value,
@@ -32,8 +31,10 @@
     display: initial;
 }
 
-.ui-axes_math-location_value.dragging .ui-axes_math-location_value-logical_value,
-.ui-axes_math-location_value.dragging .ui-axes_math-location_value-numeric_value {
+.ui-axes_math-location_value.dragging
+    .ui-axes_math-location_value-logical_value,
+.ui-axes_math-location_value.dragging
+    .ui-axes_math-location_value-numeric_value {
     display: none;
 }
 

--- a/lib/js/components/axes-math.mjs
+++ b/lib/js/components/axes-math.mjs
@@ -608,7 +608,7 @@ export class UIAxesMathLocationValues extends _UIBaseList {
     static UIItem = UIAxesMathLocationValue; // extends _UIBaseList.UIItem
     static ITEM_DATA_TRANSFER_TYPE_PATH = DATA_TRANSFER_TYPES.AXESMATH_LOCATION_VALUE_PATH;
     static ITEM_DATA_TRANSFER_TYPE_CREATE = DATA_TRANSFER_TYPES.AXESMATH_LOCATION_VALUE_CREATE;
-    static DROP_INSERT_DIRECTION = _UIBaseList.DROP_INSERT_DIRECTION_HORIZONTAL;
+    DROP_INSERT_DIRECTION = _UIBaseList.DROP_INSERT_DIRECTION_HORIZONTAL;
 
     _createNewItem(targetPath, insertPosition, items, value) {
         const newItem = items.constructor.Model.createPrimalDraft(items.dependencies)

--- a/lib/js/components/axes-math.mjs
+++ b/lib/js/components/axes-math.mjs
@@ -46,9 +46,11 @@ import {
     SelectAndDragByOptions
 } from './layouts/stage-and-actors.mjs';
 
- import {
+import {
     binarySearch
- }  from './animation-fundamentals.mjs';
+} from './animation-fundamentals.mjs';
+
+import './axes-math-location-value.css'
 
 // START will be a module for calculateRegisteredKeyframes
 /**
@@ -523,6 +525,13 @@ export class UIAxesMathLocationValue extends _UIBaseList.UIItem {
               , [inputNumericValue, 'numeric_value']
               , [output, 'output']
         ]);
+
+        element.addEventListener('focusin', () => element.classList.add('focus'));
+        element.addEventListener('focusout', e => {
+            if (!element.contains(e.relatedTarget)) {
+                element.classList.remove('focus');
+            }
+        });
 
         for(const item of logicalValueType.enumItems) {
             const option = this._domTool.createElement('option');

--- a/lib/js/components/basics.mjs
+++ b/lib/js/components/basics.mjs
@@ -2743,7 +2743,6 @@ function _dragstartHandlerMethod(event) {
     //      "It is important to set the data in the right order, from most-specific to least-specific."
     event.dataTransfer.setData(this.ITEM_DATA_TRANSFER_TYPE_PATH, `${path}`);
     event.dataTransfer.setData('text/plain', `[TypeRoof ${this.ITEM_DATA_TRANSFER_TYPE_PATH}: ${path}]`);
-    this.element.classList.add('dragging');
     // MDN: During the drag operation, drag effects may be modified to
     // indicate that certain effects are allowed at certain locations.
     // 'copy', 'move', 'link'
@@ -2756,10 +2755,19 @@ function _dragstartHandlerMethod(event) {
     event.dataTransfer.effectAllowed = 'all';
     event.dataTransfer.setDragImage(this.element, 0 , 0);
 
-    // lose focus, otherwise it will jump to the next element after
-    // the successful drop.
-    if(this.element.matches(':focus-within'))
-        this._domTool.document.activeElement.blur();
+    // Take the snapshot of the element while it is stable
+    event.dataTransfer.setDragImage(this.element, 0 , 0);
+
+    // Defer the state changes. This gives Chromium time to finalize the
+    // drag image registration.
+    requestAnimationFrame(() => {
+        this.element.classList.add('dragging');
+
+        // lose focus safely after the drag operation has officially kicked off
+        if (this.element.matches(':focus-within')) {
+            this._domTool.document.activeElement.blur();
+        }
+    })
 }
 
 function _dragendHandlerMethod(/*event*/) {

--- a/lib/js/components/layouts/stage-and-actors.mjs
+++ b/lib/js/components/layouts/stage-and-actors.mjs
@@ -419,7 +419,7 @@ function* languageTagGen(
  */
 const REGISTERED_GENERIC_KEYMOMENT_FIELDS = Object.freeze(new FreezableSet([
     'textRun', 'textAlign', 'positioningHorizontal', 'positioningVertical'
-  , 'direction', 'heightTreatment', 'charGroup', 'charGroups', 'showCellBoxes', 'cellAlignment'
+  , 'direction', 'heightTreatment', 'charGroup', 'charGroups', 'showCellBoxes', 'cellAlignment', 'presets'
 ]));
 
 const REGISTERED_METAMODEL_FIELDS = Object.freeze(new FreezableMap([

--- a/lib/js/components/layouts/type-tools-grid.mjs
+++ b/lib/js/components/layouts/type-tools-grid.mjs
@@ -11,10 +11,6 @@ import {
   , InternalizedDependency
   , BooleanDefaultTrueModel
   , CoherenceFunction
-  , deserializeSync
-  , SERIALIZE_OPTIONS
-  , SERIALIZE_FORMAT_OBJECT
-  , unwrapPotentialWriteProxy
 } from '../../metamodel.mjs';
 
 import {
@@ -183,6 +179,11 @@ import {
     ProseMirror
 } from '../prosemirror/integration.typeroof.jsx';
 
+import {
+    CUSTOM_PRESET_KEY
+  , applyPresets
+} from '../presets.mjs';
+
 import { schemaSpec as proseMirrorDefaultSchema } from "../prosemirror/very-simple-schema";
 
     /**
@@ -226,14 +227,29 @@ const GRID_CONTENT_OPTIONS = new Map([
         ['A-Z', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ']
       , ['a-z', 'abcdefghijklmnopqrstuvwxyz']
       , ['0-9', '0123456789']
-      , ['custom', null]
+      , [CUSTOM_PRESET_KEY, null]
       // I'd like to load a custom value for this from the registered-properties
       // type: 'custom' with a customText: 'H'
-    ])
+    ].map(([key, textContent])=>{
+        const documentData = {
+            "typeKey": "doc",
+            "content": [
+                {
+                    "typeKey": "paragraph",
+                    "content": [
+                        {
+                            "typeKey": "text",
+                            "text": textContent
+                        }
+                    ]
+                },
+            ]
+        };
+        return [key, {document: documentData}];
+    }))
   , _grid_content_options_keys = Array.from(GRID_CONTENT_OPTIONS.keys())
   , GridContentTypeModel = _AbstractEnumModel.createClass('GridContentTypeModel',
         _grid_content_options_keys, _grid_content_options_keys.at(0))
-  , GENERATED_DATA = Symbol.for('GENERATED_DATA')
   , GridContentModel = _AbstractStructModel.createClass(
          'GridContentModel'
        , ['type', GridContentTypeModel]
@@ -246,85 +262,16 @@ const GRID_CONTENT_OPTIONS = new Map([
        // a flag, the content could be useful for debugging maybe.
        // In a second step the data is skipped in serialization, so we
        // re-generate it on load.
-       //
        , ['document', NodeModel]
        , CoherenceFunction.create(
-        [
-            "type",
-            "document",
-        ],
-        function initDocument({
-            type,
-            document,
-        }) {
-            // If the document is custom the type should become "custom" as well
-            // when the type has changed to a not "custom" key, the document
-            // content must be changed as well.
-
-            // Actually "type has a draft", value may still be the same, but the
-            // presence of a draft is enough so far.
-            const typeHasChanged = !!unwrapPotentialWriteProxy(type, 'draft')
-                // For a ProseMirror document, this seems to be sufficient,
-                // otherwise may be hard to detect!
-              , isNewDocument = document.get("content").size === 0
-              , contentType = type.value
-              ;
-            if (contentType !== 'custom' && (isNewDocument || typeHasChanged)) {
-                const data = {
-                        "typeKey": "doc",
-                        "content": [
-                            {
-                                "typeKey": "paragraph",
-                                "content": [
-                                    {
-                                        "typeKey": "text",
-                                        "text": GRID_CONTENT_OPTIONS.get(contentType)
-                                    }
-                                ]
-                            },
-                        ]
-                    },
-                    serializeOptions = Object.assign(
-                        {},
-                        SERIALIZE_OPTIONS,
-                        {
-                            format: SERIALIZE_FORMAT_OBJECT,
-                        },
-                    ),
-                    newItem = deserializeSync(
-                        NodeModel,
-                        document.dependencies,
-                        data,
-                        serializeOptions,
-                    );
-                for (const [key, enrty] of newItem.entries())
-                    document.set(key, enrty);
-                // The idea is that the symbol will disappear when edited
-                // outside of this function and hence we would set the
-                // type to "custom"
-
-                // documentDraft will be undefined if it is not a draft yet
-                const documentDraft = unwrapPotentialWriteProxy(document, 'draft');
-                // Actually the mere presence of this GENERATED_DATA
-                // symbol is enough, the value may be helping when debugging.
-                documentDraft[GENERATED_DATA] = contentType;
-            }
-            else if (contentType === 'custom' && typeHasChanged) {
-                // The document data will have to be serialized.
-                // Make sure the draft is going to be a new item
-                // and not reverted back, so that the GENERATED_DATA symbol
-                // cannot stick! Create a copy:
-                const content = document.get('content')
-                  , newContent = NodeModel.fields.get('content').createPrimalDraft(content.dependencies)
-                  ;
-                newContent.push(...content.value);
-                document.set('content', newContent);
-            }
-            else if(!Object.hasOwn(unwrapPotentialWriteProxy(document), GENERATED_DATA)) {
-                // document has been customized/not generate/created in here.
-                type.value = 'custom';
-            }
-        })
+            ["type", "document"],
+            applyPresets.bind(
+                null,
+                "type",
+                GRID_CONTENT_OPTIONS,
+                CUSTOM_PRESET_KEY,
+            ),
+        ),
     )
   , GridPropertiesModel = _AbstractStructModel.createClass(
         'GridPropertiesModel'

--- a/lib/js/components/layouts/type-tools-grid.mjs
+++ b/lib/js/components/layouts/type-tools-grid.mjs
@@ -250,29 +250,6 @@ const GRID_CONTENT_OPTIONS = new Map([
   , _grid_content_options_keys = Array.from(GRID_CONTENT_OPTIONS.keys())
   , GridContentTypeModel = _AbstractEnumModel.createClass('GridContentTypeModel',
         _grid_content_options_keys, _grid_content_options_keys.at(0))
-  , GridContentModel = _AbstractStructModel.createClass(
-         'GridContentModel'
-       , ['type', GridContentTypeModel]
-       // In order to not having to serialize the document when the content
-       // is fully generated from GRID_CONTENT_OPTIONS or more generally
-       // to not serialize generated content this introduces the global
-       // GENERATED_DATA symbol.
-       // The first step is marking the content as generated here, using
-       // the GENERATED_DATA symbol. The presence alone is relevant, like
-       // a flag, the content could be useful for debugging maybe.
-       // In a second step the data is skipped in serialization, so we
-       // re-generate it on load.
-       , ['document', NodeModel]
-       , CoherenceFunction.create(
-            ["type", "document"],
-            applyPresets.bind(
-                null,
-                "type",
-                GRID_CONTENT_OPTIONS,
-                CUSTOM_PRESET_KEY,
-            ),
-        ),
-    )
   , GridPropertiesModel = _AbstractStructModel.createClass(
         'GridPropertiesModel'
         // Could make this a dict of DimensionRangeModel e.g. x would be an
@@ -310,9 +287,19 @@ const GRID_CONTENT_OPTIONS = new Map([
       , ['properties', GridPropertiesModel]
         // could be more complex, with a few presets and `custom` would
         // make user input possible
-      , ['content', GridContentModel]
+      , ['presets', GridContentTypeModel]
+      , ['document', NodeModel]
       , ['showParameters', BooleanDefaultTrueModel]
       , ['showCaptions', BooleanDefaultTrueModel]
+      , CoherenceFunction.create(
+            ["presets", "document"],
+            applyPresets.bind(
+                null,
+                "presets",
+                GRID_CONTENT_OPTIONS,
+                CUSTOM_PRESET_KEY,
+            ),
+        ),
     )
   ;
 
@@ -601,9 +588,6 @@ function getGridPropertiesPPSMap(parentPPSRecord, Type) {
             prefix = DIMENSION;
         else if(modelFieldType === ColorModel)
             prefix = COLOR;
-        //else if (modelFieldName === 'content') {
-        //    registryKey = `gridContent`
-        //}
 
         if(prefix === null)
             // don't make a UI for this
@@ -1988,7 +1972,7 @@ class UIGridCellsProvider extends _BaseContainerComponent {
             }
           , dependencyMappings = [
                 // [identifier, 'cellContent@']
-                ['content/document', 'document']
+                ['document', 'document']
           ]
           , Constructor = ProseMirror
           , args = [proseMirrorDefaultSchema]
@@ -2040,7 +2024,7 @@ class UIGrid extends _BaseContainerComponent {
                 }
               , [
                     [`typeSpecProperties@${widgetBus.rootPath.toString()}`, '@properties']
-                  , 'content'
+                  , 'document'
                   , 'showCaptions'
                   , 'showParameters'
                 ]
@@ -2112,7 +2096,7 @@ class TypeToolsGridController extends _BaseContainerComponent {
                 }
               , [
                        // This way, it's hard to only update when the
-                       // 'content' changed!
+                       // 'document' changed!
                        ['.', 'typeSpec']
                       // parent is always two levels above from here
                       // as this is children/{index}
@@ -2149,13 +2133,13 @@ class TypeToolsGridController extends _BaseContainerComponent {
           , [
                 { zone: 'general'
                 , rootPath: widgetBus.rootPath
-                , relativeRootPath: Path.fromParts('.', 'content', 'type')
+                , relativeRootPath: Path.fromParts('.', 'presets')
                 }
               , [
                     ['.', 'value']
                 ]
               , UISelectInput
-              , 'Content'
+              , 'Presets'
               , new Map(GridContentTypeModel.enumItems.map(value=>[value, value]))// items
             ]
           , [
@@ -2196,7 +2180,7 @@ class TypeToolsGridController extends _BaseContainerComponent {
                 {zone: 'grid-layout'}
               , [
                     [`typeSpecProperties@${widgetBus.rootPath.toString()}`, '@properties']
-                  , 'content'
+                  , 'document'
                   , 'showCaptions'
                   , 'showParameters'
                 ]

--- a/lib/js/components/presets.mjs
+++ b/lib/js/components/presets.mjs
@@ -1,0 +1,108 @@
+import {
+    _AbstractListModel,
+    deserializeSync,
+    SERIALIZE_OPTIONS,
+    SERIALIZE_FORMAT_OBJECT,
+    unwrapPotentialWriteProxy,
+} from "../metamodel.mjs";
+
+const GENERATED_DATA = Symbol.for("GENERATED_DATA");
+
+export const CUSTOM_PRESET_KEY = "custom";
+
+function copyToDraft(item) {
+    const draftItem = item.constructor.createPrimalDraft(item.dependencies);
+    for (const [key, entry] of item) {
+        if (item instanceof _AbstractListModel) draftItem.push(entry);
+        else draftItem.set(key, entry);
+    }
+    return draftItem;
+}
+
+/**
+ * By injecting PRESETS_OPTIONS and CUSTOM_PRESET_KEY I hope this can
+ * be used as a pattern for other preset implementations as well!
+ */
+export function applyPresets(
+    presetsFieldName,
+    PRESETS_OPTIONS,
+    CUSTOM_PRESET_KEY,
+    valuesMap,
+    { isNew /*, wasSerialized*/, setFn },
+) {
+    const {
+        [presetsFieldName]: presets,
+        ...settables // {charGroups, template}}
+    } = valuesMap;
+
+    // - If any item of settables is customized the presets.value
+    //   should become CUSTOM_PRESET_KEY ("custom") as well.
+    // - When the type has changed to a not "custom" key, the
+    //  settables must be changed as well.
+    //
+    // The idea is that the GENERATED_DATA symbol will
+    // disappear when edited outside of this function
+    // and hence we would set the type to "custom"
+
+    const presetsChanged = !!unwrapPotentialWriteProxy(presets, "draft");
+
+    let apply = "";
+    if (presets.value !== CUSTOM_PRESET_KEY && (isNew || presetsChanged)) {
+        // isNew: wouldn't have the data applied
+        // presetsChanged: whatever the data is now, it will be replaced
+        apply = "preset";
+    } else if (presets.value === CUSTOM_PRESET_KEY && presetsChanged) {
+        apply = CUSTOM_PRESET_KEY;
+    } else {
+        const presetData = PRESETS_OPTIONS.get(presets.value);
+        for (const [key, entry] of Object.entries(settables)) {
+            // depending on the presence in the presets we skip the entry here!
+            // i.e. if charGroups is settable, but the current preset doesn't
+            // set it, it can't trigger apply(CUSTOM_PRESET_KEY).
+            if (presetData && !(key in presetData)) continue;
+            const unwrapped = unwrapPotentialWriteProxy(entry);
+            if (!Object.hasOwn(unwrapped, GENERATED_DATA)) {
+                // entry has been customized/not generated/created in here.
+                apply = CUSTOM_PRESET_KEY;
+                presets.value = CUSTOM_PRESET_KEY;
+                break;
+            }
+        }
+    }
+    // apply a state if required...
+    if (apply === "preset") {
+        const serializeOptions = Object.assign({}, SERIALIZE_OPTIONS, {
+                format: SERIALIZE_FORMAT_OBJECT,
+            }),
+            presetData = PRESETS_OPTIONS.get(presets.value);
+        for (const [key, entry] of Object.entries(settables)) {
+            if (!(key in presetData)) continue;
+            const Ctor = unwrapPotentialWriteProxy(entry).constructor,
+                serializedData = presetData[key],
+                newEntry = deserializeSync(
+                    Ctor,
+                    entry.dependencies,
+                    serializedData,
+                    serializeOptions,
+                );
+            // the new Entry is immutable and we need it to
+            // be a draft with actual changes so the GENERATED_DATA
+            // flag sticks to it...
+            const entryDraft = copyToDraft(newEntry);
+            // Actually the mere presence of this GENERATED_DATA
+            // symbol is enough, the value may be helping when debugging.
+            entryDraft[GENERATED_DATA] = presets.value;
+            setFn(key, entryDraft);
+        }
+    } else if (apply === CUSTOM_PRESET_KEY) {
+        // The data will have to be serialized.
+        // Make sure the drafts are going to be new items
+        // and not reverted back, so that the GENERATED_DATA
+        // symbol cannot stick! Create a copy:
+        for (const [key, entry] of Object.entries(settables)) {
+            const newEntry = copyToDraft(entry); // => new item
+            // this should have deleted any trace of GENERATED_DATA
+            setFn(key, newEntry);
+        }
+    }
+}

--- a/lib/js/metamodel/coherence-function.ts
+++ b/lib/js/metamodel/coherence-function.ts
@@ -1,9 +1,16 @@
-import { FreezableSet } from "./base-model.ts";
+import { FreezableSet, _BaseModel } from "./base-model.ts";
 
 // FIXME/TODO: type can be anything that _AbstractStruct.get would return
 // Also as Proxies!
 export type ValueMap = Record<string, unknown>;
-export type CoherenceFn = (valueMap: ValueMap) => void;
+
+export type CoherenceMeta = {
+    isNew: boolean;
+    wasSerialized: boolean;
+    setFn(key: string, entry: _BaseModel): void;
+};
+
+export type CoherenceFn = (valueMap: ValueMap, meta: CoherenceMeta) => void;
 
 export class CoherenceFunction {
     // Use the definite assignment assertion '!'

--- a/lib/js/metamodel/struct-model.ts
+++ b/lib/js/metamodel/struct-model.ts
@@ -729,6 +729,7 @@ export class _AbstractStructModel extends _BaseContainerModel {
                 return [value, serializeOptions];
             };
         // Don't keep this.
+        const wasSerialized = this[_PRIMARY_SERIALIZED_VALUE] !== undefined;
         delete this[_PRIMARY_SERIALIZED_VALUE];
         const ctor = this.constructor as typeof _AbstractStructModel;
 
@@ -901,9 +902,32 @@ export class _AbstractStructModel extends _BaseContainerModel {
                 // This is also not yet implemented in the factory method,
                 // so there may be no way to get these dependencies accepted!
                 // localScope.set(name, coherenceFunction.fn(childDependencies));
-                const maybeGen = coherenceFunction.fn(
-                    childDependencies,
-                ) as void | Generator<ResourceRequirement, void, unknown>;
+                const maybeGen = coherenceFunction.fn(childDependencies, {
+                    isNew: this[OLD_STATE] === null,
+                    wasSerialized: wasSerialized,
+                    // setFn: this.set.bind(this)
+                    // I'm not sure if we need to guard what this function
+                    // can do further, e.g. regarding the dependencies
+                    // or types of the newly set items. However, this is
+                    // going to be restricted from the original set function
+                    // in that it can only set keys that are present
+                    // in the coherence function dependencies:
+                    setFn: (key: string, entry: _BaseModel): void => {
+                        if (!coherenceFunction.dependencies.has(key))
+                            throw new Error(
+                                `KEY ERROR ${this}: ${coherenceFunction} ` +
+                                    `is trying to set a key "${key}" that is not in its ` +
+                                    `dependencies: ${coherenceFunction.dependencies}`,
+                            );
+                        // Looks like most of the childDependencies items
+                        // are just proxies at this point, going via
+                        // this.set to have changes propagated. Also,
+                        // re-setting localScope explicitly. I'm not sure
+                        // that is required though.
+                        this.set(key, entry);
+                        localScope.set(key, this.get(key));
+                    },
+                }) as void | Generator<ResourceRequirement, void, unknown>;
                 if ((maybeGen as Generator)?.next instanceof Function)
                     yield* maybeGen as Generator<
                         ResourceRequirement,

--- a/package-lock.json
+++ b/package-lock.json
@@ -311,7 +311,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -650,7 +649,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -674,7 +672,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1894,7 +1891,6 @@
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1967,7 +1963,6 @@
       "integrity": "sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.43.0",
         "@typescript-eslint/types": "8.43.0",
@@ -2212,7 +2207,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2787,7 +2781,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -3361,8 +3354,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
       "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -3947,7 +3939,6 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6838,7 +6829,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6888,7 +6878,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -6909,7 +6898,6 @@
       "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
       "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"
@@ -7258,7 +7246,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8694,7 +8681,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8858,7 +8844,6 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
Add loading of presets to the `VideoproofContextualKeyMomentModel`.
This adds all presets the legacy version supplies, but implemented using our `TemplateModel` and `CharGroupArgumentsListModel`. When a user changes a preset, the select changes to "custom" and all of the data is serialized, if the select is changed to a preset, only the preset selected key will be serialized and the actual data is loaded from the presets.

~I hope~ the function `applyPresets` ~will work~ works as a general purpose pattern for this kind of applying presets. ~Next stop would be to apply it to~ `GridContentModel` uses it now as well as that was the precedence for this implementation, sans the newly added Metamodel/CoherenceFunction capabilities.

A future step: We can maybe use it as a base to also load presets asynchronously, from disk or from a user data source that could live in the `IndexedDB`, similar to what custom fonts do already.

This PR also fixes the drag and drop behavior in `[axes-math] UIAxesMathLocationValues` 