### PR TITLE
[feature] Show font version only if multiple fonts have the same name

### DIFF
--- a/lib/js/components/font-loading.mjs
+++ b/lib/js/components/font-loading.mjs
@@ -147,10 +147,19 @@ export class FontSelect extends _BaseComponent {
                     optGroups[name] = createOptGroup(name);
                 return optGroups[name];
             }
+          , entries = Array.from(availableFonts, ([key, {value:font}])=>[key, font, font.name])
+            // Only when the same name is installed more than once, the
+            // version is required to tell the fonts apart.
+          , nameCounts = new Map()
           ;
-        for(const [key, {value:font}] of availableFonts) {
+        for(const [/*key*/, /*font*/, name] of entries)
+            nameCounts.set(name, (nameCounts.get(name) || 0) + 1);
+
+        for(const [key, font, name] of entries) {
             const optGroup = getOptGroup(font.origin.type)
-              , textContent = font.nameVersion
+              , textContent = nameCounts.get(name) > 1
+                    ? font.nameVersion
+                    : name
               , option = this._domTool.createElement('option')
               ;
             option.value = key;

--- a/lib/js/local-font-storage.mjs
+++ b/lib/js/local-font-storage.mjs
@@ -46,7 +46,7 @@ export default class LocalFontStorage {
         // will have a blob and `fullName`, where fullName equals
         // VideproofFont.fullName which is used as the unique id for
         // the available fonts.
-        // 'nameVersion' which is used as the label.
+        // 'name' and 'nameVersion' which are used as the label.
         // `serializationNameParticles` => required to know if the font matches the serialized font
         /*const objectStore = */
 
@@ -91,6 +91,7 @@ export default class LocalFontStorage {
             .objectStore('fonts')
             .put({
                     fullName: font.fullName
+                  , name: font.name
                   , nameVersion: font.nameVersion
                   , serializationNameParticles: font.serializationNameParticles
                   , buffer: font.buffer

--- a/lib/js/model/font.mjs
+++ b/lib/js/model/font.mjs
@@ -423,11 +423,12 @@ export class VideoProofFont {
 export class VideoProofDeferredFont {
     static fromFontObject(fontObject, origin, buffer=null) {
         const font = new VideoProofFont({}, fontObject, origin);
-        return new this(origin, font.fullName, font.nameVersion, font.serializationNameParticles, buffer);
+        return new this(origin, font.fullName, font.name, font.nameVersion, font.serializationNameParticles, buffer);
     }
-    constructor(origin, fullName, nameVersion, serializationNameParticles, buffer=null) {
+    constructor(origin, fullName, name, nameVersion, serializationNameParticles, buffer=null) {
         Object.defineProperties(this, {
             fullName: {value: fullName, writable: false, enumerable: true}
+          , name: {value: name, writable: false, enumerable: true}
           , nameVersion: {value: nameVersion, writable: false, enumerable: true}
           , serializationNameParticles: {value: serializationNameParticles, writable: false, enumerable: true}
           , origin: {value: origin, writable: false, enumerable: true}

--- a/lib/js/shell.mjs
+++ b/lib/js/shell.mjs
@@ -378,7 +378,7 @@ class FontManager {
           // we really only need to supply:
           //        name, version and if we want to customize fullName, that as well
 
-        let fullName, nameVersion, serializationParticles;
+        let fullName, name, nameVersion, serializationParticles;
         if(!metaData.name || !metaData.version) {
             // we need to load the fontObject/parse the buffer
             if(!fontBuffer)
@@ -387,11 +387,13 @@ class FontManager {
              , font = new VideoProofFont({}, fontObject, origin)
              ;
             fullName = metaData.fullName || font.fullName;
+            name = font.name;
             nameVersion = font.nameVersion;
             serializationParticles = font.serializationNameParticles;
         }
         else {
-            const {name, version} = metaData;
+            const {version} = metaData;
+            name = metaData.name;
             fullName = metaData.fullName || VideoProofFont.fullName(name, version, origin.type);
             nameVersion = VideoProofFont.nameVersion(name, version);
             serializationParticles = [name, version];
@@ -400,6 +402,7 @@ class FontManager {
         const deferredFont = new VideoProofDeferredFont(
                             origin
                           , fullName
+                          , name
                           , nameVersion
                           , serializationParticles
                           , fontBuffer/* or null */)
@@ -457,7 +460,7 @@ class FontManager {
      */
     async _loadFontFromMessage(fontBuffer, metaData={}, conflictResolutionAction=null) {
         const origin = new FontOriginFile(metaData.name);
-        let fullName, nameVersion, serializationParticles;
+        let fullName, name, nameVersion, serializationParticles;
         if(!metaData.name || !metaData.version) {
             // this is a nice path but to live update from postMessage,
             // I'm not so sure if we should pursue it!
@@ -466,13 +469,15 @@ class FontManager {
              , font = new VideoProofFont({}, fontObject, origin)
              ;
             fullName = metaData.fullName || font.fullName;
+            name = font.name;
             nameVersion = font.nameVersion;
             serializationParticles = font.serializationNameParticles;
         }
         else {
             // From postMessage I'd expect this path, so there's full
             // control!.
-            const {name, version} = metaData;
+            const {version} = metaData;
+            name = metaData.name;
             fullName = metaData.fullName || VideoProofFont.fullName(name, version, origin.type);
             nameVersion = VideoProofFont.nameVersion(name, version);
             serializationParticles = [name, version];
@@ -481,6 +486,7 @@ class FontManager {
         const deferredFont = new VideoProofDeferredFont(
                             origin
                           , fullName
+                          , name
                           , nameVersion
                           , serializationParticles
                           , fontBuffer)
@@ -562,9 +568,12 @@ class FontManager {
         // Because we are bootstrapping availableFontsDraft  is available!
         const availableFontsDraft = this._requireStateDependencyDraft('availableFonts');
         for await(const entry of this._localFontStorage.getAll()) {
-            const font = new VideoProofDeferredFont(
+                  // serializationNameParticles is [name, version]
+            const [name, ] = entry.serializationNameParticles
+              , font = new VideoProofDeferredFont(
                             FontOrigin.fromDB(entry.origin)
                           , entry.fullName
+                          , name
                           , entry.nameVersion
                           , entry.serializationNameParticles
                           , null);

--- a/lib/js/shell.mjs
+++ b/lib/js/shell.mjs
@@ -568,8 +568,9 @@ class FontManager {
         // Because we are bootstrapping availableFontsDraft  is available!
         const availableFontsDraft = this._requireStateDependencyDraft('availableFonts');
         for await(const entry of this._localFontStorage.getAll()) {
-                  // serializationNameParticles is [name, version]
-            const [name, ] = entry.serializationNameParticles
+            // Fall back for entries stored before "name" was
+            // persisted: serializationNameParticles is [name, version].
+            const name = entry.name || entry.serializationNameParticles[0]
               , font = new VideoProofDeferredFont(
                             FontOrigin.fromDB(entry.origin)
                           , entry.fullName


### PR DESCRIPTION
As suggested by @dberlow this week, showing the font version is not strictly necessary.
With this PR, the version is only displayed If multiple versions of a font with the same name are loaded into TypeRoof.

<img width="455" height="435" alt="Screenshot 2026-08-19 at 17 09 58" src="https://github.com/user-attachments/assets/32a5ac03-4e33-4171-825b-8b918cf7b425" />

_Screenshot of the font dropdown showing 2 different versions of Roboto Flex Regular._