### PR TITLE
Add dev mode check to show/hide dev layouts

### DIFF
--- a/lib/js/components/main-ui.mjs
+++ b/lib/js/components/main-ui.mjs
@@ -43,6 +43,25 @@ import * as Ramp from './layouts/ramp/index.typeroof.jsx';
 import * as TypeToolsGrid from './layouts/type-tools-grid.mjs';
 import * as ExampleReactLayout from './dev-layouts/example-react.mjs';
 
+/**
+ * Development only layouts (LAYOUT_GROUP_DEVELOPMENT) are available when
+ * running from a development server, or when the "dev" search parameter
+ * is present in the URL, e.g. "?dev".
+ */
+const checkDevMode = () => {
+        // The "dev" search parameter enables the development layouts
+        // in any build, e.g. to inspect them in a production build.
+        if(new URLSearchParams(globalThis.location?.search).has('dev'))
+            return true;
+        // Vite replaces import.meta.env statically: DEV is true when
+        // served by the vite dev server and false in `vite build` output.
+        // Hence a production build served locally, e.g. via
+        // `npm run build:serve`, is not in dev mode.
+        return import.meta.env.DEV === true;
+    }
+  , isDevMode = checkDevMode()
+  ;
+
 const LAYOUT_GROUP_DEFAULT = Symbol('LAYOUT_GROUP_DEFAULT')
   , LAYOUT_GROUP_DEVELOPMENT = Symbol('LAYOUT_GROUP_DEVELOPMENT')
   , LAYOUT_GROUP_VIDEO_PROOF = Symbol('LAYOUT_GROUP_VIDEO_PROOF')
@@ -52,7 +71,9 @@ const LAYOUT_GROUP_DEFAULT = Symbol('LAYOUT_GROUP_DEFAULT')
             [LAYOUT_GROUP_DEFAULT, {label: 'TypeRoof Original'}]
           , [LAYOUT_GROUP_VIDEO_PROOF, {label: 'Video Proof'}]
           , [LAYOUT_GROUP_TYPE_TOOLS, {label: 'Type Tools'}]
-          , [LAYOUT_GROUP_DEVELOPMENT, {label: 'Development Artifacts'}]
+          , ...(isDevMode
+                ? [[LAYOUT_GROUP_DEVELOPMENT, {label: 'Development Artifacts'}]]
+                : [])
         ].map(([key, data], index)=>[key, Object.freeze(Object.assign({}, data, {index}))])
     )
   ;
@@ -64,12 +85,16 @@ Object.freeze(LAYOUT_GROUPS);
 export {LAYOUT_GROUPS};
 
 export const Layouts = Object.freeze([
-    ['Example', 'Example', ExampleLayout, LAYOUT_GROUP_DEVELOPMENT]
-  , ['ExampleKeyMoments', 'Example Key Moments', ExampleKeyMomentsLayout, LAYOUT_GROUP_DEVELOPMENT]
-  , ['ExamplePentrek', 'Example Pentrek', PentrekLayout, LAYOUT_GROUP_DEVELOPMENT]
-  , ['ExampleReact', 'Example React', ExampleReactLayout, LAYOUT_GROUP_DEVELOPMENT]
+    ...(isDevMode
+        ? [
+              ['Example', 'Example', ExampleLayout, LAYOUT_GROUP_DEVELOPMENT]
+            , ['ExampleKeyMoments', 'Example Key Moments', ExampleKeyMomentsLayout, LAYOUT_GROUP_DEVELOPMENT]
+            , ['ExamplePentrek', 'Example Pentrek', PentrekLayout, LAYOUT_GROUP_DEVELOPMENT]
+            , ['ExampleReact', 'Example React', ExampleReactLayout, LAYOUT_GROUP_DEVELOPMENT]
+            , ['VideoproofArrayDev', 'Videoproof Array (Interim)', VideoproofArrayLayout, LAYOUT_GROUP_DEVELOPMENT]
+          ]
+        : [])
   , ['MotionStage', 'Motion Stage', MotionStageLayout, LAYOUT_GROUP_DEFAULT]
-  , ['VideoproofArrayDev', 'Videoproof Array (Interim)', VideoproofArrayLayout, LAYOUT_GROUP_DEVELOPMENT]
   , ['Videoproof', 'Video Proof', VideoproofLayout, LAYOUT_GROUP_VIDEO_PROOF]
   , ['TypeToolsGrid', 'Grid', TypeToolsGrid, LAYOUT_GROUP_TYPE_TOOLS]
 


### PR DESCRIPTION
The "Development Artifacts" group in the "Layout" dropdown will be shown only when running the app in dev mode, i.e.:
- When running it with `npm run dev`;
- When running a production build (`npm run build:serve`) with a `?dev` parameter added to the URL.
