### PR TITLE
Share state as link

### DIFF
--- a/lib/js/components/app-menu.typeroof.jsx
+++ b/lib/js/components/app-menu.typeroof.jsx
@@ -106,6 +106,13 @@ export class AppMenu extends _BaseContainerComponent {
                     </button>
                 </li>
             ),
+            shareLinkElement = (
+                <li>
+                    <button onClick={() => this._onClickShareLink()}>
+                        Copy share link
+                    </button>
+                </li>
+            ),
             zones = new Map([["main", mainElement]]);
         widgetBus.insertElement(mainElement);
 
@@ -119,6 +126,7 @@ export class AppMenu extends _BaseContainerComponent {
                     {loadStateElement}
                     {saveStateElement}
                     {manageFontsElement}
+                    {shareLinkElement}
                 </menu>,
             ],
             [
@@ -209,7 +217,11 @@ export class AppMenu extends _BaseContainerComponent {
         }
     }
 
-    _onClickSaveState() {
+    /**
+     * Serialize the app state, reporting errors under label. Returns null
+     * if serialization failed.
+     */
+    _serializeState(label) {
         const [errors, serializedValue] = serialize(this.getEntry("/"));
         if (errors.length) {
             const messages = [];
@@ -224,7 +236,41 @@ export class AppMenu extends _BaseContainerComponent {
                     `${error.name}: ${error.message} at ./${path.join("/")}`,
                 );
             }
-            this._reportError("Saving state file", messages.join("\n"));
+            this._reportError(label, messages.join("\n"));
+            return null;
+        }
+        return serializedValue;
+    }
+
+    async _onClickShareLink() {
+        const serializedValue = this._serializeState("Creating share link");
+        if (serializedValue === null) {
+            return;
+        }
+        const window_ = this._domTool.window,
+            url = new URL(window_.location.href);
+        // Drop the whitespace used to pretty print the JSON.
+        const compactValue = JSON.stringify(JSON.parse(serializedValue));
+        url.searchParams.set("state", compactValue);
+        const href = url.href;
+        try {
+            await window_.navigator.clipboard.writeText(href);
+        } catch (error) {
+            this._reportError("Copying the share link", error);
+            return;
+        }
+        const message =
+            "The share link was copied to the clipboard." +
+            (href.length > 2000
+                ? `\n\nWarning: the link is ${href.length} characters long. ` +
+                  "URLs longer than 2000 characters might not work with all browsers."
+                : "");
+        window_.alert(message);
+    }
+
+    _onClickSaveState() {
+        const serializedValue = this._serializeState("Saving state file");
+        if (serializedValue === null) {
             return;
         }
         downloadFile(

--- a/lib/js/components/app-menu.typeroof.jsx
+++ b/lib/js/components/app-menu.typeroof.jsx
@@ -250,7 +250,7 @@ export class AppMenu extends _BaseContainerComponent {
         const window_ = this._domTool.window,
             url = new URL(window_.location.href),
             compressed = await compressStateForUrl(serializedValue);
-        url.searchParams.set("state", compressed);
+        url.hash = `from-hash:${compressed}`;
         const href = url.href;
         try {
             await window_.navigator.clipboard.writeText(href);

--- a/lib/js/components/app-menu.typeroof.jsx
+++ b/lib/js/components/app-menu.typeroof.jsx
@@ -5,11 +5,11 @@ import {
 } from "./basics/component.mjs";
 import { StaticNode } from "./generic.mjs";
 import {
+    compressStateForUrl,
     createStateFileName,
     deserializeStateString,
     downloadFile,
 } from "../utils/state-file.mjs";
-
 import { getRemovableFonts, UIDialogManageFonts } from "./font-loading.mjs";
 
 /**
@@ -248,10 +248,9 @@ export class AppMenu extends _BaseContainerComponent {
             return;
         }
         const window_ = this._domTool.window,
-            url = new URL(window_.location.href);
-        // Drop the whitespace used to pretty print the JSON.
-        const compactValue = JSON.stringify(JSON.parse(serializedValue));
-        url.searchParams.set("state", compactValue);
+            url = new URL(window_.location.href),
+            compressed = await compressStateForUrl(serializedValue);
+        url.searchParams.set("state", compressed);
         const href = url.href;
         try {
             await window_.navigator.clipboard.writeText(href);
@@ -259,13 +258,7 @@ export class AppMenu extends _BaseContainerComponent {
             this._reportError("Copying the share link", error);
             return;
         }
-        const message =
-            "The share link was copied to the clipboard." +
-            (href.length > 2000
-                ? `\n\nWarning: the link is ${href.length} characters long. ` +
-                  "URLs longer than 2000 characters might not work with all browsers."
-                : "");
-        window_.alert(message);
+        window_.alert("The share link was copied to the clipboard.");
     }
 
     _onClickSaveState() {

--- a/lib/js/shell.mjs
+++ b/lib/js/shell.mjs
@@ -870,27 +870,24 @@ export class ShellController {
             const serializedValue = await response.text();
             return [deserializeStateString(Model, serializedValue), flags];
         }
+        if(parsedHash.groups.target === 'from-hash') {
+            // The compressed, base64url-encoded state as created by the
+            // "Share link" menu entry.
+            const {history} = this._contentWindow
+              , token = parsedHash.groups.payload?.trim()
+              , serializedValue = await decompressStateFromUrl(token ?? null)
+              ;
+            if(serializedValue === null || serializedValue.trim().length === 0)
+                return [null, flags];
+            const state = deserializeStateString(Model, serializedValue);
+            // Remove the state from the hash, so that it doesn't linger
+            // in the location bar and in copied links. Preserve any flags.
+            const url = new URL(location.href);
+            url.hash = flags.size ? `[${[...flags].join(',')}]` : '';
+            history.replaceState(null, '', url.href);
+            return [state, flags];
+        }
         return [null, flags];
-    }
-
-    /**
-     * Load the initial state from the "state" URL query parameter, as
-     * created by the "Share link" menu entry.
-     */
-    async _loadInitialStateFromLocationQuery(Model) {
-        const {location, history} = this._contentWindow
-          , url = new URL(location.href)
-          , rawValue = url.searchParams.get('state')
-          , serializedValue = await decompressStateFromUrl(rawValue)
-          ;
-        if(serializedValue === null || serializedValue.trim().length === 0)
-            return null;
-        const state = deserializeStateString(Model, serializedValue);
-        // Remove the "state" query parameter, so that it doesn't linger
-        // in the location bar and in copied links.
-        url.searchParams.delete('state');
-        history.replaceState(null, '', url.href);
-        return state;
     }
 
     async _allInitialResourcesLoaded(resources) {
@@ -946,13 +943,9 @@ export class ShellController {
         // that uses these flags should change on update.
         const uiFlags = new FreezableSet();
         try {
-            const [hashLikeADraft, flags] = await this._loadInitialStateFromLocationHash(ApplicationModel);
+            const [likeADraft, flags] = await this._loadInitialStateFromLocationHash(ApplicationModel);
             for(const flag of flags)
                 uiFlags.add(flag);
-            const likeADraft = hashLikeADraft !== null
-                ? hashLikeADraft
-                : await this._loadInitialStateFromLocationQuery(ApplicationModel)
-                ;
             if(likeADraft !== null)
                 await _initState(likeADraft);
         }

--- a/lib/js/shell.mjs
+++ b/lib/js/shell.mjs
@@ -872,6 +872,25 @@ export class ShellController {
         return [null, flags];
     }
 
+    /**
+     * Load the initial state from the "state" URL query parameter, as
+     * created by the "Share link" menu entry.
+     */
+    _loadInitialStateFromLocationQuery(Model) {
+        const {location, history} = this._contentWindow
+          , url = new URL(location.href)
+          , serializedValue = url.searchParams.get('state')
+          ;
+        if(serializedValue === null || serializedValue.trim().length === 0)
+            return null;
+        const state = deserializeStateString(Model, serializedValue);
+        // Remove the "state" query parameter, so that it doesn't linger
+        // in the location bar and in copied links.
+        url.searchParams.delete('state');
+        history.replaceState(null, '', url.href);
+        return state;
+    }
+
     async _allInitialResourcesLoaded(resources) {
         if(this.appReady)
             throw new Error('_allInitialResourcesLoaded must run only once.');
@@ -925,14 +944,18 @@ export class ShellController {
         // that uses these flags should change on update.
         const uiFlags = new FreezableSet();
         try {
-            const [likeADraft, flags] = await this._loadInitialStateFromLocationHash(ApplicationModel);
+            const [hashLikeADraft, flags] = await this._loadInitialStateFromLocationHash(ApplicationModel);
             for(const flag of flags)
                 uiFlags.add(flag);
+            const likeADraft = hashLikeADraft !== null
+                ? hashLikeADraft
+                : this._loadInitialStateFromLocationQuery(ApplicationModel)
+                ;
             if(likeADraft !== null)
                 await _initState(likeADraft);
         }
         catch(e) {
-            console.error(new Error(`STATE LOAD ERROR Failed to load initial state form location hash.`, {cause: e}));
+            console.error(new Error(`STATE LOAD ERROR Failed to load initial state from the location.`, {cause: e}));
         }
         Object.freeze(uiFlags);
 

--- a/lib/js/shell.mjs
+++ b/lib/js/shell.mjs
@@ -52,6 +52,7 @@ import * as harfbuzz from './vendor/harfbuzzjs/harfbuzz.mjs';
 
 import {
     deserializeStateString
+  , decompressStateFromUrl
 } from './utils/state-file.mjs';
 
 async function parseFont(fontBuffer) {
@@ -876,10 +877,11 @@ export class ShellController {
      * Load the initial state from the "state" URL query parameter, as
      * created by the "Share link" menu entry.
      */
-    _loadInitialStateFromLocationQuery(Model) {
+    async _loadInitialStateFromLocationQuery(Model) {
         const {location, history} = this._contentWindow
           , url = new URL(location.href)
-          , serializedValue = url.searchParams.get('state')
+          , rawValue = url.searchParams.get('state')
+          , serializedValue = await decompressStateFromUrl(rawValue)
           ;
         if(serializedValue === null || serializedValue.trim().length === 0)
             return null;
@@ -949,7 +951,7 @@ export class ShellController {
                 uiFlags.add(flag);
             const likeADraft = hashLikeADraft !== null
                 ? hashLikeADraft
-                : this._loadInitialStateFromLocationQuery(ApplicationModel)
+                : await this._loadInitialStateFromLocationQuery(ApplicationModel)
                 ;
             if(likeADraft !== null)
                 await _initState(likeADraft);

--- a/lib/js/utils/state-file.mjs
+++ b/lib/js/utils/state-file.mjs
@@ -21,6 +21,47 @@ export function createStateFileName(layoutKey, date = new Date()) {
     return `typeroof-${dateSegment}-${timeSegment}.${layoutKey}.json`;
 }
 
+// Pipe `bytes` through a (De)CompressionStream and collect the result.
+async function _streamThrough(transformStream, bytes) {
+    const stream = new Blob([bytes]).stream().pipeThrough(transformStream);
+    return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+function _bytesToBase64Url(bytes) {
+    let binary = '';
+    for(const byte of bytes)
+        binary += String.fromCharCode(byte);
+    return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+}
+
+function _base64UrlToBytes(text) {
+    const binary = atob(text.replaceAll('-', '+').replaceAll('_', '/'))
+      , bytes = new Uint8Array(binary.length)
+      ;
+    for(let i = 0; i < binary.length; i++)
+        bytes[i] = binary.charCodeAt(i);
+    return bytes;
+}
+
+// Compress a serialized state string into a URL-safe token, using the
+// browser's CompressionStream API (gzip) plus base64url encoding.
+export async function compressStateForUrl(serializedValue) {
+    const input = new TextEncoder().encode(serializedValue)
+      , compressed = await _streamThrough(new CompressionStream('gzip'), input)
+      ;
+    return _bytesToBase64Url(compressed);
+}
+
+// Reverse of compressStateForUrl. Returns null for a missing or empty token.
+export async function decompressStateFromUrl(rawValue) {
+    if(rawValue === null || rawValue.trim().length === 0)
+        return null;
+    const compressed = _base64UrlToBytes(rawValue.trim())
+      , decompressed = await _streamThrough(new DecompressionStream('gzip'), compressed)
+      ;
+    return new TextDecoder().decode(decompressed);
+}
+
 export function downloadFile(document, contents, fileName) {
     const url = URL.createObjectURL(new Blob([contents], {type: 'application/json'}))
       , anchor = document.createElement('a')


### PR DESCRIPTION
- Add "Copy share link" menu item;
- Share link is copied to the clipboard;
- When loading a link with the embedded state, the app deserializes the state, and then removes the URL parameter (to prevent the user from thinking the current state of the app is reflected in the URL).

~~Note: this breaks with Type Stage, Ramp, and most layouts that produce long URLs. `github.io` returns `Error: URI Too Long`. Now that we have file loading/saving, it's debatable whether link sharing should be available anyway. If really required, the solution would be saving the state into a database and generating a link that allows the app to retrieve that data.~~

Update: implemented compression of the URL parameter using ~~[lz-string](https://www.npmjs.com/package/lz-string)~~ [Compression Stream API](https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API). This seems to fix the issue with long URLs.