### PR TITLE
Implement reset to defaults

### DIFF
--- a/lib/js/components/app-menu.typeroof.jsx
+++ b/lib/js/components/app-menu.typeroof.jsx
@@ -106,6 +106,13 @@ export class AppMenu extends _BaseContainerComponent {
                     </button>
                 </li>
             ),
+            resetToDefaultsElement = (
+                <li>
+                    <button onClick={() => this._onClickResetToDefaults()}>
+                        Reset to defaults
+                    </button>
+                </li>
+            ),
             zones = new Map([["main", mainElement]]);
         widgetBus.insertElement(mainElement);
 
@@ -118,7 +125,10 @@ export class AppMenu extends _BaseContainerComponent {
                 <menu>
                     {loadStateElement}
                     {saveStateElement}
+                    <hr />
                     {manageFontsElement}
+                    <hr />
+                    {resetToDefaultsElement}
                 </menu>,
             ],
             [
@@ -278,6 +288,37 @@ export class AppMenu extends _BaseContainerComponent {
         } finally {
             this._manageFontsDialog = null;
             dialog.destroy();
+        }
+    }
+
+    /**
+     * Reset the document, i.e. activeState, to a primal (default) state.
+     *
+     * The remaining root entries are either dependencies (availableLayouts,
+     * availableFonts, installedFonts) or links derived from the selections
+     * (layoutTypeModel, font), hence replacing the wrapped activeState is
+     * all it takes, and activeLayoutKey/activeFontKey persist untouched.
+     */
+    async _onClickResetToDefaults() {
+        const message =
+            "Reset to defaults?\n\n" +
+            "This discards the current document. " +
+            "The layout and font selections are kept.";
+        if (!this._domTool.window.confirm(message)) {
+            return;
+        }
+        try {
+            await this._changeState(() => {
+                const activeState = this.getEntry("activeState");
+                // Fonts used only by the discarded document become unused,
+                // and without this we'd miss freeing them.
+                this.widgetBus.requireReviewResources();
+                activeState.wrapped = activeState.WrappedType.createPrimalDraft(
+                    activeState.wrapped.dependencies,
+                );
+            });
+        } catch (error) {
+            this._reportError("Resetting to defaults", error);
         }
     }
 


### PR DESCRIPTION
Renamed the command name to "Reset to defaults", because it reset other properties, like colors.

Closes #133 

One caveat mentioned by Claude:

> One caveat I'd rather name than bury: assigning through the entry relies on the proxy's set trap at [potential-write-proxy.ts:505](vscode-webview://1led8p9nemcc4uektbt0odoln72a2g7d23ovrt974vff9docshgn/lib/js/metamodel/potential-write-proxy.ts#L505), whose own comment says "just for completeness, I don't think it's yet actually used, but it could." The logic reads correct — set wrapped throws immutableWriteError, the trap catches it and retries against the materialized draft — but we'd be its first caller, and I haven't exercised it at runtime. That's the thing to watch when you click the menu item. Prettier and eslint pass.