### PR TITLE
Leave comments

### DIFF
--- a/lib/js/components/layouts/motion-stage.mjs
+++ b/lib/js/components/layouts/motion-stage.mjs
@@ -48,6 +48,7 @@ import {
 
 import {
     _BaseLayoutModel
+  , CommentsModel
 } from '../main-model.mjs';
 
 import {
@@ -158,6 +159,11 @@ import {
     UIshowProcessedProperties
 } from '../processed-properties.mjs';
 
+import {
+    createCommentsWidgets
+} from '../ui-comments.mjs';
+
+
 const StageSizeNumberModel = _AbstractNumberModel.createClass(
         'SizeNumberModel'
       , {
@@ -209,6 +215,7 @@ const StageSizeNumberModel = _AbstractNumberModel.createClass(
     )
   , MotionStageModel = _BaseLayoutModel.createClass(
         'MotionStageModel'
+      , ['comments', CommentsModel]
       , ...timeControlModelMixin
          // same as in_BaseActorModel, but this is not an actor,
          // these properties are the root of the inheritance.
@@ -2862,6 +2869,7 @@ class MotionStageController extends _BaseContainerComponent {
               , PropertiesManager
               , new Map([...zones, ['main', propertiesManagerContainer]])
             ]
+          , ...createCommentsWidgets(zones)
         ];
         // The manager may not be present in test harnesses; then the
         // layout works without the layout-scoping class.

--- a/lib/js/components/layouts/ramp/index.typeroof.jsx
+++ b/lib/js/components/layouts/ramp/index.typeroof.jsx
@@ -2,7 +2,7 @@ import {
     _BaseContainerComponent,
     SimpleProtocolHandler,
 } from "../../basics/component.mjs";
-import { _BaseLayoutModel } from "../../main-model.mjs";
+import { _BaseLayoutModel, CommentsModel } from "../../main-model.mjs";
 import {
     PathModelOrEmpty,
     Path,
@@ -51,10 +51,13 @@ import {
 import { LengthModel } from "../../length-models.mjs";
 import DEFAULT_STATE from "../../../../assets/type-stage-initial-state.json" with { type: "json" };
 
+import { createCommentsWidgets } from "../../ui-comments.mjs";
+
 //  We can't create the self-reference directly
 //, TypeSpecModelMap: TypeSpec.get('children') === _AbstractOrderedMapModel.createClass('TypeSpecModelMap', TypeSpec)
 const RampModel = _BaseLayoutModel.createClass(
     "RampModel",
+    ["comments", CommentsModel],
     // The root TypeSpec
     ["typeSpec", TypeSpecModel],
     ["editingTypeSpec", PathModelOrEmpty],
@@ -448,6 +451,7 @@ class RampController extends _BaseContainerComponent {
                 StylePatchPropertiesManager,
                 new Map([...zones, ["main", stylePatchesManagerContainer]]),
             ],
+            ...createCommentsWidgets(zones),
         ];
         this._initWidgets(widgets);
     }

--- a/lib/js/components/layouts/type-stage/index.typeroof.jsx
+++ b/lib/js/components/layouts/type-stage/index.typeroof.jsx
@@ -2,7 +2,7 @@ import {
     _BaseContainerComponent,
     SimpleProtocolHandler,
 } from "../../basics/component.mjs";
-import { _BaseLayoutModel } from "../../main-model.mjs";
+import { _BaseLayoutModel, CommentsModel } from "../../main-model.mjs";
 import {
     PathModelOrEmpty,
     Path,
@@ -65,6 +65,8 @@ import {
 } from "../../document-renderer-mode/model.mjs";
 
 import { UIDocumentRendererModeSelector } from "../../document-renderer-mode/ui-selector.typeroof.jsx";
+
+import { createCommentsWidgets } from "../../ui-comments.mjs";
 
 //  We can't create the self-reference directly
 //, TypeSpecModelMap: TypeSpec.get('children') === _AbstractOrderedMapModel.createClass('TypeSpecModelMap', TypeSpec)
@@ -173,6 +175,7 @@ export function createTypeStageModelVariantWithDefaults(
     };
     return _BaseLayoutModel.createClass(
         name,
+        ["comments", CommentsModel],
         // The root TypeSpec
         ["typeSpec", TypeSpecModel],
         ["editingTypeSpec", PathModelOrEmpty],
@@ -631,6 +634,7 @@ class TypeStageController extends _BaseContainerComponent {
                 MarkSpecPropertiesManager,
                 new Map([...zones, ["main", markSpecManagerContainer]]),
             ],
+            ...createCommentsWidgets(zones),
         ];
         // The manager may not be present in test harnesses; then the
         // layout works without the layout-scoping class (CSS falls back

--- a/lib/js/components/layouts/type-tools-grid.mjs
+++ b/lib/js/components/layouts/type-tools-grid.mjs
@@ -107,6 +107,7 @@ import {
 
 import {
     _BaseLayoutModel
+  , CommentsModel
   , InstalledFontModel
 } from '../main-model.mjs';
 
@@ -188,6 +189,11 @@ import {
 } from '../presets.mjs';
 
 import { schemaSpec as proseMirrorDefaultSchema } from "../prosemirror/very-simple-schema";
+
+import {
+    createCommentsWidgets
+} from '../ui-comments.mjs';
+
 
     /**
      * This is a dynamic type!
@@ -287,6 +293,7 @@ const GRID_CONTENT_OPTIONS = new Map([
     )
   , TypeToolsGridModel = _BaseLayoutModel.createClass(
         'TypeToolsGridModel'
+      , ['comments', CommentsModel]
       , ['properties', GridPropertiesModel]
         // could be more complex, with a few presets and `custom` would
         // make user input possible
@@ -2217,6 +2224,7 @@ class TypeToolsGridController extends _BaseContainerComponent {
                     actorApplyCSSColors(gridLayoutContainer, propertyValuesMap, getDefault, colorPropertiesMap);
                 }
             ]
+          , ...createCommentsWidgets(zones)
         ];
         this._initWidgets(widgets);
     }

--- a/lib/js/components/layouts/videoproof.typeroof.jsx
+++ b/lib/js/components/layouts/videoproof.typeroof.jsx
@@ -32,7 +32,7 @@ import {
 
 import { createIcon } from "../icons.mjs";
 
-import { _BaseLayoutModel } from "../main-model.mjs";
+import { _BaseLayoutModel, CommentsModel } from "../main-model.mjs";
 
 import { FontSelect } from "../font-loading.mjs";
 
@@ -114,6 +114,7 @@ import { UILanguageTagCollapsible as UILanguageTag } from "../language-tags.type
 import { renderAxesParameterDisplay } from "../axes-parameters.mjs";
 
 import { UIColorChooserTwoColorsWithSwap } from "../ui-color-chooser.mjs";
+import { createCommentsWidgets } from "../ui-comments.mjs";
 
 const activatableVideoproofActorTypes = (() => {
     const videoproofActors = [
@@ -831,6 +832,7 @@ const LAYER_TYPE_KEY = "LayerActorModel";
 // optimization strategies.
 const VideoproofModel = _BaseLayoutModel.createClass(
     "VideoproofModel",
+    ["comments", CommentsModel],
     ...timeControlModelMixin,
     ...StaticDependency.createWithInternalizedDependency(
         "availableAxesMathItemTypes",
@@ -2406,6 +2408,7 @@ class VideoproofController extends _BaseTypeDrivenContainerComponentMixin(
                 videoProofActorUpdateDefaultsDependencies,
                 { zone: "keyMoments", label: null }, //keyMomentsOptions
             ],
+            ...createCommentsWidgets(zones),
         ];
         this._initWidgets(widgets);
     }

--- a/lib/js/components/main-model.mjs
+++ b/lib/js/components/main-model.mjs
@@ -1,7 +1,7 @@
 import {
        unwrapPotentialWriteProxy
       , _AbstractStructModel
-      // , _AbstractListModel
+      , _AbstractListModel
       //, _AbstractMapModel
       , _AbstractOrderedMapModel
       , _AbstractDynamicStructModel
@@ -34,6 +34,17 @@ export const InstalledFontModel = _AbstractGenericModel.createClass('InstalledFo
       , ['groupKey', LayoutGroupKeyModel]
     )
   , AvailableLayoutsModel = _AbstractOrderedMapModel.createClass('AvailableLayoutsModel', AvailableLayoutModel)
+  , CommentModel = _AbstractStructModel.createClass(
+        'CommentModel'
+        // The position of the element the comment is attached to, as a
+        // path of child indexes, starting at the root .typeroof-layout
+        // element, e.g. "3/5/2" is the 2nd child of the 5th child of the
+        // 3rd child of the root element. The empty string is the root
+        // element itself.
+      , ['path', StringModel]
+      , ['comment', StringModel]
+    )
+  , CommentsModel = _AbstractListModel.createClass('CommentsModel', CommentModel)
   , AvailableFontsModel = _AbstractOrderedMapModel.createClass('AvailableFontsModel', DeferredFontModel)
   , InstalledFontsModel = _AbstractOrderedMapModel.createClass('InstalledFontsModel', InstalledFontModel)
   , ApplicationModel = _AbstractStructModel.createClass(

--- a/lib/js/components/ui-comments.css
+++ b/lib/js/components/ui-comments.css
@@ -1,0 +1,141 @@
+/**
+ * Comments are positioned within the layout zone, hence it must be the
+ * containing block for the absolutely positioned comment balloons.
+ */
+.typeroof-main > .typeroof-layout {
+    position: relative;
+}
+
+/* While picking a position for a new comment the whole document uses
+ * the crosshair cursor, so it doesn't change over the layout contents.
+ */
+body.ui_comments-picking,
+body.ui_comments-picking * {
+    cursor: crosshair !important;
+}
+
+/**
+ * A zero sized anchor at the origin of the layout zone content box, so
+ * that the children can use coordinates relative to it directly.
+ */
+.ui_comments {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 0;
+    overflow: visible;
+    z-index: 10;
+    /* Don't block interaction with the layout, the balloons opt back in. */
+    pointer-events: none;
+}
+
+.ui_comment {
+    position: absolute;
+    /* The tip is at the bottom center, pointing at the stored position. */
+    transform: translate(-50%, -100%);
+    margin-top: -0.75em;
+    box-sizing: border-box;
+    /* Without max-content the shrink-to-fit width would depend on the
+     * distance to the right edge of the layout zone.
+     */
+    width: max-content;
+    max-width: 300px;
+    border-radius: 0.5em;
+    background: hsl(50, 85%, 80%);
+    color: black;
+    font-size: 0.9rem;
+    line-height: 1.3;
+    overflow-wrap: break-word;
+    pointer-events: auto;
+    display: flex;
+    align-items: stretch;
+
+    /* The author rule above beats the user agent [hidden] rule. */
+    &[hidden] {
+        display: none;
+    }
+
+    &::after {
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        margin-left: -0.75em;
+        border: 0.75em solid transparent;
+        border-top-color: hsl(50, 85%, 80%);
+        border-bottom-width: 0;
+    }
+}
+
+.ui_comment-text {
+    max-height: 80px;
+    overflow-y: auto;
+    padding: 0.5em 0.75em;
+}
+
+.ui_comment-delete_button {
+    display: flex;
+    align-items: center;
+    padding: 0.5em;
+    border: 0;
+    background: hsl(50, 85%, 80%);
+    color: inherit;
+    cursor: pointer;
+    height: auto;
+
+    .material-symbols-outlined {
+        font-size: 1.2em;
+    }
+}
+
+.ui_comment-draft {
+    padding: 0.5em;
+    width: 260px;
+    align-items: flex-end;
+    flex-direction: column;
+    gap: 0.5em;
+}
+
+.ui_comment-input {
+    background-color: hsl(50, 85%, 90%);
+    border-color: hsl(50, 50%, 50%);
+    width: 100%;
+    height: auto;
+    box-sizing: border-box;
+
+    &:focus-within {
+        outline: 1px solid hsl(50, 50%, 50%);
+    }
+}
+
+.ui_comment-buttons {
+    display: flex;
+    gap: 0.5em;
+}
+
+.ui_comments-add_button {
+    display: block;
+}
+
+.ui_comments-show_comments {
+    display: flex;
+    align-items: center;
+    gap: 0.25em;
+    margin-top: 0.25em;
+}
+
+/* The draft balloon stays visible, it is not a comment yet and hiding
+ * it would strand the user in an invisible input.
+ */
+.ui_comments-hidden .ui_comment:not(.ui_comment-draft) {
+    display: none;
+}
+
+/* The layout element a comment is anchored to, or that is hovered while
+ * picking a position for a new comment.
+ */
+.ui_comments-highlight {
+    outline: 3px solid hsla(50, 85%, 50%, 25%) !important;
+    position: absolute;
+}

--- a/lib/js/components/ui-comments.mjs
+++ b/lib/js/components/ui-comments.mjs
@@ -1,0 +1,686 @@
+import {
+    _BaseComponent
+  , _BaseContainerComponent
+} from './basics/component.mjs';
+
+import {
+    Collapsible
+} from './generic.mjs';
+
+import {
+    createIcon
+} from './icons.mjs';
+
+import './ui-comments.css';
+
+/**
+ * Connects the "Add comment..." button, which lives in the sidebar, with
+ * the UICommentsOverlay, which lives in the layout zone. Both receive the
+ * same bridge instance from the MainUIController.
+ */
+export class CommentsBridge {
+    constructor() {
+        this._startAddComment = null;
+        this._commentsVisible = true;
+        this._changeListeners = new Set();
+    }
+    /**
+     * Called by the UICommentsOverlay. There's only one overlay, hence
+     * registering just overrides a previous, destroyed, overlay.
+     */
+    setStartAddComment(fn) {
+        this._startAddComment = fn;
+    }
+    unsetStartAddComment(fn) {
+        if(this._startAddComment === fn)
+            this._startAddComment = null;
+    }
+    get canAddComment() {
+        return this._startAddComment !== null;
+    }
+    startAddComment() {
+        if(this._startAddComment !== null)
+            this._startAddComment();
+    }
+
+    /**
+     * Whether the comments in the layout are shown. This is ephemeral
+     * UI state, it is deliberately not part of the model.
+     */
+    get commentsVisible() {
+        return this._commentsVisible;
+    }
+    set commentsVisible(visible) {
+        const _visible = !!visible;
+        if(this._commentsVisible === _visible)
+            return;
+        this._commentsVisible = _visible;
+        for(const listener of this._changeListeners)
+            listener(this._commentsVisible);
+    }
+    addCommentsVisibleListener(fn) {
+        this._changeListeners.add(fn);
+    }
+    removeCommentsVisibleListener(fn) {
+        this._changeListeners.delete(fn);
+    }
+}
+
+/**
+ * The button that initiates picking a position for a new comment.
+ */
+export class UIAddCommentButton extends _BaseComponent {
+    constructor(widgetBus, commentsBridge) {
+        super(widgetBus);
+        this._commentsBridge = commentsBridge;
+        this.element = this._domTool.createElement('button', {
+                'class': 'ui_comments-add_button'
+              , type: 'button'
+            }
+          , 'Add comment...'
+        );
+        this._onClick = this._onClickHandler.bind(this);
+        this.element.addEventListener('click', this._onClick);
+        this._insertElement(this.element);
+    }
+    _onClickHandler() {
+        this._commentsBridge.startAddComment();
+    }
+    destroy() {
+        this.element.removeEventListener('click', this._onClick);
+    }
+}
+
+/**
+ * Toggles the visibility of the comments in the layout.
+ */
+export class UIShowCommentsCheckbox extends _BaseComponent {
+    constructor(widgetBus, commentsBridge) {
+        super(widgetBus);
+        this._commentsBridge = commentsBridge;
+        this._input = this._domTool.createElement('input', {type: 'checkbox'});
+        this._input.checked = this._commentsBridge.commentsVisible;
+        this.element = this._domTool.createElement('label', {
+                'class': 'ui_comments-show_comments'
+            }
+          , [this._input, this._domTool.createElement('span', {}, 'Show comments')]
+        );
+        this._onChange = this._onChangeHandler.bind(this);
+        this._onCommentsVisibleChange = this._onCommentsVisibleChangeHandler.bind(this);
+        this._input.addEventListener('change', this._onChange);
+        this._commentsBridge.addCommentsVisibleListener(this._onCommentsVisibleChange);
+        this._insertElement(this.element);
+    }
+    _onChangeHandler() {
+        this._commentsBridge.commentsVisible = this._input.checked;
+    }
+    _onCommentsVisibleChangeHandler(visible) {
+        this._input.checked = visible;
+    }
+    destroy() {
+        this._input.removeEventListener('change', this._onChange);
+        this._commentsBridge.removeCommentsVisibleListener(this._onCommentsVisibleChange);
+    }
+}
+
+/**
+ * Renders one balloon per item in the "comments" list and implements the
+ * interaction to create a new comment: pick a position in the layout,
+ * then type the comment into a draft balloon.
+ */
+export class UICommentsOverlay extends _BaseComponent {
+    constructor(widgetBus, commentsBridge, layoutElement) {
+        super(widgetBus);
+        this._commentsBridge = commentsBridge;
+        this._layoutElement = layoutElement;
+        this._draftElement = null;
+        this._draftPath = null;
+        this._draftInput = null;
+        // [path, balloonElement] for each rendered comment, so the
+        // balloons can be repositioned without re-rendering.
+        this._balloons = [];
+        // The pending _updatePositions animation frame, see _onResize.
+        this._updatePositionsFrame = null;
+        // The pending "start picking" timeout, see _startAddComment.
+        this._armPickingTimeout = null;
+        this._isPicking = false;
+        // The element under the cursor while picking, it is highlighted
+        // like the anchors of the existing comments.
+        this._hoveredElement = null;
+
+        this.element = this._domTool.createElement('div', {'class': 'ui_comments'});
+        // The highlights are drawn as boxes on top of the highlighted
+        // elements, rather than styling those elements directly, so the
+        // layout contents are not touched at all. The container keeps
+        // them together, so they survive re-rendering the balloons.
+        this._highlightsElement = this._domTool.createElement('div'
+                                    , {'class': 'ui_comments-highlights'});
+        this.element.append(this._highlightsElement);
+        this._insertElement(this.element);
+
+        this._onArmPicking = this._onArmPickingHandler.bind(this);
+        this._onPickClick = this._onPickClickHandler.bind(this);
+        this._onCancelPicking = this._onCancelPickingHandler.bind(this);
+        this._onPickHover = this._onPickHoverHandler.bind(this);
+        this._onDraftSubmit = this._onDraftSubmitHandler.bind(this);
+        this._onDraftCancel = this._onDraftCancelHandler.bind(this);
+        this._onDraftKeydown = this._onDraftKeydownHandler.bind(this);
+        this._startAddComment = this._startAddCommentHandler.bind(this);
+        this._commentsBridge.setStartAddComment(this._startAddComment);
+
+        this._onCommentsVisibleChange = this._setCommentsVisible.bind(this);
+        this._commentsBridge.addCommentsVisibleListener(this._onCommentsVisibleChange);
+        this._setCommentsVisible(this._commentsBridge.commentsVisible);
+
+        // The balloon positions are derived from the layout contents,
+        // hence they must be updated when the layout is resized/reflowed.
+        this._onResize = this._onResizeHandler.bind(this);
+        this._domTool.window.addEventListener('resize', this._onResize);
+        this._resizeObserver = new this._domTool.window.ResizeObserver(this._onResize);
+        this._resizeObserver.observe(this._layoutElement);
+        // The layout contents can reflow without changing the box of the
+        // layout element itself, e.g. when a sidebar edit changes an actor.
+        // The ResizeObserver doesn't fire in that case, the mutations of
+        // the layout contents do.
+        this._onMutation = this._onMutationHandler.bind(this);
+        this._mutationObserver = new this._domTool.window.MutationObserver(this._onMutation);
+        this._mutationObserver.observe(this._layoutElement, {
+            childList: true
+          , subtree: true
+          , attributes: true
+          , characterData: true
+        });
+    }
+
+    /**
+     * Positioning the balloons mutates the overlay, those mutations must
+     * not schedule another update, that would never stop.
+     */
+    _onMutationHandler(records) {
+        for(const record of records) {
+            if(this.element.contains(record.target))
+                continue;
+            this._onResize();
+            return;
+        }
+    }
+
+    /**
+     * Resize events can come in bursts, updating once per frame is enough.
+     */
+    _onResizeHandler() {
+        if(this._updatePositionsFrame !== null)
+            return;
+        this._updatePositionsFrame = this._domTool.window.requestAnimationFrame(()=>{
+            this._updatePositionsFrame = null;
+            this._updatePositions();
+        });
+    }
+
+    _cancelUpdatePositions() {
+        if(this._updatePositionsFrame === null)
+            return;
+        this._domTool.window.cancelAnimationFrame(this._updatePositionsFrame);
+        this._updatePositionsFrame = null;
+    }
+
+    /**
+     * Move the balloons to where their elements are now. A balloon whose
+     * path doesn't resolve anymore is hidden, it may become resolvable
+     * again, e.g. when the layout element is re-created.
+     */
+    _updatePositions() {
+        const entries = this._draftPath !== null && this._draftElement !== null
+                ? [...this._balloons, [this._draftPath, this._draftElement]]
+                : this._balloons
+                ;
+        for(const [path, element] of entries) {
+            const position = this._getPathPosition(path);
+            if(position === null) {
+                element.hidden = true;
+                continue;
+            }
+            const [x, y] = position;
+            element.hidden = false;
+            element.style.setProperty('left', `${x}px`);
+            element.style.setProperty('top', `${y}px`);
+        }
+        this._updateHighlights();
+    }
+
+    /**
+     * The box of element within the layout zone content box, i.e. in
+     * the same coordinates as the balloon positions.
+     */
+    _getElementBox(element) {
+        const layoutRect = this._layoutElement.getBoundingClientRect()
+          , rect = element.getBoundingClientRect()
+          ;
+        return [
+            rect.left - layoutRect.left + this._layoutElement.scrollLeft
+          , rect.top - layoutRect.top + this._layoutElement.scrollTop
+          , rect.width
+          , rect.height
+        ];
+    }
+
+    /**
+     * The anchor elements of the rendered comments, of the draft and the
+     * element under the cursor while picking are highlighted, so it is
+     * visible which part of the layout a comment belongs to.
+     */
+    _updateHighlights() {
+        // Hidden comments have no visible balloon, hence their anchors
+        // are not highlighted either.
+        const paths = this._commentsBridge.commentsVisible
+                ? this._balloons.map(([path])=>path)
+                : []
+                ;
+        if(this._draftPath !== null)
+            paths.push(this._draftPath);
+        const elements = new Set();
+        for(const path of paths) {
+            const element = this._resolveElementPath(path);
+            if(element !== null)
+                elements.add(element);
+        }
+        if(this._hoveredElement !== null)
+            elements.add(this._hoveredElement);
+        this._domTool.clear(this._highlightsElement);
+        for(const element of elements) {
+            const [x, y, width, height] = this._getElementBox(element);
+            this._highlightsElement.append(
+                this._domTool.createElement('div', {
+                    'class': 'ui_comments-highlight'
+                  , style: `left: ${x}px; top: ${y}px;`
+                          + `width: ${width}px; height: ${height}px;`
+                })
+            );
+        }
+    }
+
+    _setCommentsVisible(visible) {
+        this.element.classList.toggle('ui_comments-hidden', !visible);
+        this._updateHighlights();
+    }
+
+    get _document() {
+        return this._domTool.document;
+    }
+
+    /**
+     * The click that triggered this is still propagating, hence the
+     * document level listener is only attached after it finished,
+     * otherwise it would pick a position immediately.
+     */
+    _startAddCommentHandler() {
+        if(this._isPicking || this._armPickingTimeout !== null)
+            return;
+        this._armPickingTimeout = setTimeout(this._onArmPicking, 0);
+    }
+
+    _onArmPickingHandler() {
+        this._armPickingTimeout = null;
+        this._isPicking = true;
+        this._document.body.classList.add('ui_comments-picking');
+        this._document.addEventListener('click', this._onPickClick, true);
+        this._document.addEventListener('keydown', this._onCancelPicking, true);
+        this._document.addEventListener('mousemove', this._onPickHover, true);
+    }
+
+    _stopPicking() {
+        if(this._armPickingTimeout !== null) {
+            clearTimeout(this._armPickingTimeout);
+            this._armPickingTimeout = null;
+        }
+        if(!this._isPicking)
+            return;
+        this._isPicking = false;
+        this._document.body.classList.remove('ui_comments-picking');
+        this._document.removeEventListener('click', this._onPickClick, true);
+        this._document.removeEventListener('keydown', this._onCancelPicking, true);
+        this._document.removeEventListener('mousemove', this._onPickHover, true);
+        this._setHoveredElement(null);
+    }
+
+    /**
+     * The highlight follows the cursor while picking, so it is clear
+     * which element the click is going to anchor the comment to.
+     */
+    _onPickHoverHandler(event) {
+        this._setHoveredElement(this._layoutElement.contains(event.target)
+                                    ? event.target
+                                    : null);
+    }
+
+    _setHoveredElement(element) {
+        // The overlay is not part of the layout contents, a comment
+        // can't be anchored to it.
+        const _element = element !== null && !this.element.contains(element)
+                ? element
+                : null
+                ;
+        if(this._hoveredElement === _element)
+            return;
+        this._hoveredElement = _element;
+        this._updateHighlights();
+    }
+
+    _onPickClickHandler(event) {
+        // Clicking outside of the layout aborts, so the crosshair cursor
+        // doesn't get stuck when the user changes their mind.
+        if(!this._layoutElement.contains(event.target)) {
+            this._stopPicking();
+            return;
+        }
+        // The layout must not react to this click, it only selects the
+        // position for the new comment.
+        event.preventDefault();
+        event.stopPropagation();
+        this._stopPicking();
+
+        this._showDraft(this._getElementPath(event.target));
+    }
+
+    /**
+     * The children of the layout element that can be addressed by a
+     * comment path. The overlay itself is not part of the layout, it
+     * must not shift the indexes of its siblings.
+     */
+    _getPathChildren(element) {
+        return Array.from(element.children)
+                    .filter(child=>child !== this.element);
+    }
+
+    /**
+     * A path of child indexes from the root layout element to element,
+     * e.g. "3/5/2". The empty string is the layout element itself.
+     */
+    _getElementPath(element) {
+        const indexes = [];
+        let current = element;
+        while(current !== this._layoutElement) {
+            const parent = current.parentElement;
+            if(parent === null)
+                // Not within the layout, shouldn't happen, as the caller
+                // checks for containment.
+                return '';
+            indexes.unshift(this._getPathChildren(parent).indexOf(current));
+            current = parent;
+        }
+        return indexes.join('/');
+    }
+
+    /**
+     * The inverse of _getElementPath. Returns null if the path can't be
+     * resolved, e.g. because the layout changed since the comment was
+     * created.
+     */
+    _resolveElementPath(path) {
+        let current = this._layoutElement;
+        if(path === '')
+            return current;
+        for(const index of path.split('/')) {
+            const child = this._getPathChildren(current)[parseInt(index, 10)];
+            if(child === undefined)
+                return null;
+            current = child;
+        }
+        return current;
+    }
+
+    /**
+     * The position within the layout zone content box the balloon tip
+     * points at: the top center of the element. Returns null if the
+     * path can't be resolved.
+     */
+    _getPathPosition(path) {
+        const element = this._resolveElementPath(path);
+        if(element === null)
+            return null;
+        const layoutRect = this._layoutElement.getBoundingClientRect()
+          , rect = element.getBoundingClientRect()
+            // The balloon is centered on x, keep it from overflowing the
+            // left edge of the layout zone, it is at most 300px wide.
+          , x = Math.max(rect.left - layoutRect.left + this._layoutElement.scrollLeft
+                            + rect.width / 2, 150)
+          , y = rect.top - layoutRect.top + this._layoutElement.scrollTop
+          ;
+        return [x, y];
+    }
+
+    _onCancelPickingHandler(event) {
+        if(event.key === 'Escape') {
+            this._stopPicking();
+            return;
+        }
+    }
+
+    _removeDraft() {
+        if(this._draftElement === null)
+            return;
+        this._draftElement.remove();
+        this._draftElement = null;
+        this._draftPath = null;
+        this._draftInput = null;
+        this._updateHighlights();
+    }
+
+    /**
+     * The draft handlers operate on the current draft, there's at most
+     * one at a time, hence they can be bound once in the constructor.
+     */
+    _onDraftSubmitHandler() {
+        const path = this._draftPath
+          , comment = this._draftInput.value.trim()
+          ;
+        this._removeDraft();
+        // An empty comment would create a balloon without content,
+        // submitting it is treated like cancelling.
+        if(comment === '')
+            return;
+        this._addComment(path, comment);
+    }
+
+    _onDraftCancelHandler() {
+        this._removeDraft();
+    }
+
+    _onDraftKeydownHandler(event) {
+        if(event.key === 'Enter') {
+            event.preventDefault();
+            this._onDraftSubmit();
+        }
+        else if(event.key === 'Escape') {
+            event.preventDefault();
+            this._removeDraft();
+        }
+    }
+
+    _showDraft(path) {
+        this._removeDraft();
+        const position = this._getPathPosition(path);
+        if(position === null)
+            return;
+        const [x, y] = position;
+        const input = this._domTool.createElement('textarea', {
+                'class': 'ui_comment-input'
+              , placeholder: 'Comment...'
+              , rows: 2
+            })
+          , okButton = this._domTool.createElement('button', {type: 'button'}, 'Ok')
+          , cancelButton = this._domTool.createElement('button', {type: 'button'}, 'Cancel')
+          , draft = this._domTool.createElement('div', {
+                    'class': 'ui_comment ui_comment-draft'
+                  , style: `left: ${x}px; top: ${y}px;`
+                }
+              , [
+                    input
+                  , this._domTool.createElement('div'
+                        , {'class': 'ui_comment-buttons'}
+                        , [okButton, cancelButton])
+                ]
+            )
+          ;
+        okButton.addEventListener('click', this._onDraftSubmit);
+        cancelButton.addEventListener('click', this._onDraftCancel);
+        input.addEventListener('keydown', this._onDraftKeydown);
+        this.element.append(draft);
+        this._draftElement = draft;
+        this._draftPath = path;
+        this._draftInput = input;
+        this._updateHighlights();
+        input.focus();
+    }
+
+    _addComment(path, comment) {
+        return this._changeState(()=>{
+            const comments = this.getEntry('comments')
+              , newComment = comments.constructor.Model.createPrimalDraft(comments.dependencies)
+              ;
+            newComment.getDraftFor('path').value = path;
+            newComment.getDraftFor('comment').value = comment;
+            comments.push(newComment);
+        });
+    }
+
+    _deleteComment(key) {
+        const question = 'Delete this comment?';
+        if(!this._domTool.window.confirm(question))
+            return;
+        return this._changeState(()=>{
+            this.getEntry('comments').delete(key);
+        });
+    }
+
+    _renderComments(comments) {
+        // The draft is not part of the model and the highlights are
+        // updated separately, both must survive re-rendering.
+        for(const element of Array.from(this.element.children)) {
+            if(element !== this._draftElement && element !== this._highlightsElement)
+                element.remove();
+        }
+        const balloons = [];
+        this._balloons = [];
+        for(const [key, comment] of comments) {
+            const deleteButton = this._domTool.createElement('button', {
+                    'class': 'ui_comment-delete_button'
+                  , type: 'button'
+                  , title: 'Delete this comment.'
+                }
+              , createIcon('delete')
+            );
+            // The key is only valid for this rendering, however, the
+            // comments are re-rendered whenever the list changes.
+            deleteButton.addEventListener('click', ()=>this._deleteComment(key));
+            // The layout may have changed since the comment was created,
+            // in that case the element is gone and the balloon is hidden
+            // by _updatePositions, until the element is back.
+            const path = comment.get('path').value
+              , position = this._getPathPosition(path)
+              , [x, y] = position !== null ? position : [0, 0]
+              , balloon = this._domTool.createElement('div', {
+                    'class': 'ui_comment'
+                  , style: `left: ${x}px; top: ${y}px;`
+                  , ...(position === null ? {hidden: ''} : {})
+                }
+              , [
+                    this._domTool.createElement('div'
+                        , {'class': 'ui_comment-text'}
+                        , comment.get('comment').value)
+                  , deleteButton
+                ]
+            );
+            balloons.push(balloon);
+            this._balloons.push([path, balloon]);
+        }
+        // Keep the draft, if any, on top of the balloons.
+        if(this._draftElement !== null)
+            this._draftElement.before(...balloons);
+        else
+            this.element.append(...balloons);
+        this._updateHighlights();
+    }
+
+    update(changedMap) {
+        if(changedMap.has('comments'))
+            this._renderComments(changedMap.get('comments'));
+    }
+
+    destroy() {
+        this._cancelUpdatePositions();
+        this._resizeObserver.disconnect();
+        this._mutationObserver.disconnect();
+        this._domTool.window.removeEventListener('resize', this._onResize);
+        this._stopPicking();
+        this._removeDraft();
+        this._commentsBridge.unsetStartAddComment(this._startAddComment);
+        this._commentsBridge.removeCommentsVisibleListener(this._onCommentsVisibleChange);
+    }
+}
+
+/**
+ * The "Comments" collapsible in the sidebar.
+ */
+export class UICommentsCollapsible extends _BaseContainerComponent {
+    constructor(widgetBus, _zones, commentsBridge, togglerLabel='Comments'
+                        , isOpened=false) {
+        const localZoneElement = widgetBus.domTool.createElement('div', {'class': 'ui_comments-panel'})
+          , contentsZoneElement = widgetBus.domTool.createElement('div')
+          , zones = new Map([..._zones
+                , ['main', localZoneElement]
+                , ['contents', contentsZoneElement]])
+          ;
+        super(widgetBus, zones);
+        this._insertElement(localZoneElement);
+
+        const widgets = [
+            [
+                {zone: 'main'}
+              , []
+              , Collapsible
+              , togglerLabel
+              , contentsZoneElement
+              , isOpened
+            ]
+          , [
+                {zone: 'contents'}
+              , []
+              , UIAddCommentButton
+              , commentsBridge
+            ]
+          , [
+                {zone: 'contents'}
+              , []
+              , UIShowCommentsCheckbox
+              , commentsBridge
+            ]
+        ];
+        this._initWidgets(widgets);
+    }
+}
+
+/**
+ * The widget definitions a layout controller must add in order to have
+ * comments: the overlay in the "layout" zone and the sidebar collapsible
+ * in the "after-main" zone, both sharing one UIComments instance.
+ */
+export function createCommentsWidgets(zones) {
+    const commentsBridge = new CommentsBridge();
+    return [
+        [
+            {zone: 'layout'}
+          , ['comments']
+          , UICommentsOverlay
+          , commentsBridge
+          , zones.get('layout')
+        ]
+      , [
+            {zone: 'after-main'}
+          , []
+          , UICommentsCollapsible
+          , zones
+          , commentsBridge
+        ]
+    ];
+}

--- a/lib/js/tests/setup.ts
+++ b/lib/js/tests/setup.ts
@@ -1,0 +1,11 @@
+import { vi } from "vitest";
+
+const ResizeObserverMock = vi.fn(
+    class {
+        observe = vi.fn();
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+    },
+);
+
+vi.stubGlobal("ResizeObserver", ResizeObserverMock);

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -25,6 +25,7 @@ export default defineConfig({
         },
     ],
     test: {
+        setupFiles: ['lib/js/tests/setup.ts'],
         include: ['lib/js/**/*.test.mjs'],
         exclude: ['lib/js/vendor/**', '**/node_modules/**'],
     },


### PR DESCRIPTION
Closes #132 and #137

The user can now add multiple comments to a layout.
Each comment is anchored to an element on the layout, which is highlighted with a light yellow outline. This should be equivalent to Legacy's "Capture Selection" feature.
Comments visibility can be toggled on/off.
Comments are exported when saving a state file and are visible when loaded (comment visibility is not exported).

<img width="1369" height="472" alt="Screenshot 2026-09-09 at 15 45 12" src="https://github.com/user-attachments/assets/e6bac825-9b9f-41be-b3d2-0e1031ab23b2" />

<img width="1314" height="472" alt="Screenshot 2026-09-09 at 15 45 50" src="https://github.com/user-attachments/assets/4c339bb1-cd02-4cbf-9756-66b30405acca" />

_Disclaimer: this PR was mostly done by Claude, but I also reviewed it and made adjustments manually._