### PR TITLE
Preserve Videoproof actor when resetting to defaults

### DIFF
--- a/lib/js/components/app-menu.typeroof.jsx
+++ b/lib/js/components/app-menu.typeroof.jsx
@@ -73,7 +73,13 @@ class AppMenuItem extends _BaseComponent {
 }
 
 export class AppMenu extends _BaseContainerComponent {
-    constructor(widgetBus) {
+    /**
+     * layouts is the application's Layouts list, i.e. the
+     * [key, label, LayoutModule, groupKey] entries that also create the
+     * layout controllers. It is used to find the controller of the active
+     * layout, which can hook into the reset to defaults.
+     */
+    constructor(widgetBus, layouts = []) {
         const h = widgetBus.domTool.h,
             mainElement = <div class="typeroof-app-menu"></div>,
             stateFileInput = (
@@ -183,6 +189,7 @@ export class AppMenu extends _BaseContainerComponent {
 
         super(widgetBus, zones, widgets);
 
+        this._layouts = layouts;
         this._stateFileInput = stateFileInput;
         this._manageFontsDialog = null;
         this._menuItemIds = menuItemWidgets.map(([settings]) => settings.id);
@@ -346,6 +353,15 @@ export class AppMenu extends _BaseContainerComponent {
         if (!this._domTool.window.confirm(message)) {
             return;
         }
+        // A layout controller can preserve a bit of its state across the
+        // reset, e.g. the videoproof layout keeps the actor selection,
+        // which is more of a layout mode than a document setting.
+        const LayoutController = this._getActiveLayoutController(),
+            capturedState = LayoutController?.captureStateForReset
+                ? LayoutController.captureStateForReset(
+                      this.getEntry("activeState"),
+                  )
+                : null;
         try {
             await this._changeState(() => {
                 const activeState = this.getEntry("activeState");
@@ -356,9 +372,33 @@ export class AppMenu extends _BaseContainerComponent {
                     activeState.wrapped.dependencies,
                 );
             });
+            if (capturedState !== null) {
+                // A separate change, as the structure to restore into is
+                // created by the CoherenceFunctions of the reset above.
+                await this._changeState(() => {
+                    LayoutController.restoreStateAfterReset(
+                        this.getEntry("activeState"),
+                        capturedState,
+                    );
+                });
+            }
         } catch (error) {
             this._reportError("Resetting to defaults", error);
         }
+    }
+
+    /**
+     * The controller class of the currently active layout or null, if
+     * the layouts are unknown to this menu.
+     */
+    _getActiveLayoutController() {
+        const WrappedType = this.getEntry("activeState").WrappedType;
+        for (const [, , Layout] of this._layouts) {
+            if (Layout.Model === WrappedType) {
+                return Layout.Controller;
+            }
+        }
+        return null;
     }
 
     _reportError(label, error) {

--- a/lib/js/components/layouts/videoproof.typeroof.jsx
+++ b/lib/js/components/layouts/videoproof.typeroof.jsx
@@ -1947,6 +1947,44 @@ class VideoproofContainerStyler extends StaticNode {
 class VideoproofController extends _BaseTypeDrivenContainerComponentMixin(
     _BaseContainerComponent,
 ) {
+    /**
+     * The videoproof actor, i.e. the "Current" selection of the actor
+     * select, one of the activatableVideoproofActorTypes. See the
+     * actorsStructure CoherenceFunction for the enforced structure.
+     */
+    static ACTOR_TYPE_KEY_PATH =
+        "./activeActors/0/instance/activeActors/0/actorTypeKey";
+
+    /**
+     * Reset to defaults hook: the actor selection is more of a layout
+     * mode than a document setting, hence it survives the reset, while
+     * everything else, including the settings of the actor itself, is
+     * discarded. Returns the state that restoreStateAfterReset restores.
+     */
+    static captureStateForReset(activeState) {
+        return {
+            actorTypeKey: getEntry(
+                activeState,
+                VideoproofController.ACTOR_TYPE_KEY_PATH,
+            ).value,
+        };
+    }
+
+    /**
+     * Counterpart of captureStateForReset, called with a draft of the
+     * freshly reset activeState. Setting the actorTypeKey is just what
+     * the actor select does, the CoherenceFunctions take care of
+     * instantiating the matching actor.
+     */
+    static restoreStateAfterReset(activeState, capturedState) {
+        const actorTypeKey = getDraftEntry(
+            activeState,
+            VideoproofController.ACTOR_TYPE_KEY_PATH,
+        );
+        if (actorTypeKey.value !== capturedState.actorTypeKey)
+            actorTypeKey.value = capturedState.actorTypeKey;
+    }
+
     constructor(widgetBus, _zones) {
         const generalControlsContainer = widgetBus.domTool.createElement(
                 "div",

--- a/lib/js/components/main-ui.mjs
+++ b/lib/js/components/main-ui.mjs
@@ -157,6 +157,7 @@ export class MainUIController extends _BaseContainerComponent {
                   'installedFonts'
                 ]
               , AppMenu
+              , Layouts
             ]
           , [
                 {zone: 'main'}

--- a/lib/js/main-player.mjs
+++ b/lib/js/main-player.mjs
@@ -343,6 +343,7 @@ export class MainUIController extends _BaseContainerComponent {
                   'installedFonts'
                 ]
               , AppMenu
+              , Layouts
             ]
           , [
                 {zone: 'main'}

--- a/lib/js/wikipedia/main.mjs
+++ b/lib/js/wikipedia/main.mjs
@@ -282,7 +282,7 @@ export class MainUIController extends _BaseContainerComponent {
                     ];
                 },
             ),
-            [{ zone: "main" }, [], AppMenu, LAYOUT_GROUPS],
+            [{ zone: "main" }, [], AppMenu, Layouts],
             [{ zone: "main" }, [], StaticNode, layoutAndFontContainer],
             [
                 { zone: "layout-and-font" },


### PR DESCRIPTION
When using "Reset to defaults", we want to preserve the current Videoproof actor (Array or Contextual).

Link #133 

_Disclaimer: this PR was mostly done by Claude, but I also reviewed it and made adjustments manually._